### PR TITLE
Conv2d: Add stride support to runAtenConv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sconsign.dblite
 CatalogDir/
+CatalogDir_localhost_8109/
 bin/
 build/
 libraries/

--- a/src/conv2d_proj/headers/Conv2DSelect.h
+++ b/src/conv2d_proj/headers/Conv2DSelect.h
@@ -26,9 +26,9 @@ public:
 
     Conv2DSelect() {}
 
-    Conv2DSelect(Handle<TensorData> filters, unsigned int stride = 1, std::string convMode = "aten-conv2d") {
+    Conv2DSelect(Handle<TensorData> filters, std::string convMode = "aten-conv2d", int stride = 1) {
 
-        //make sure it's a 4D tensor
+        //make sure it's a 3D tensor
         assert(filters->numRanks = 4);
 
         //set up the kernel and kernel dimensions
@@ -60,7 +60,7 @@ public:
     }
 
 
-    Handle<TensorData> runEigenSpatial(TensorData& input,  int z, int y, int x) {
+    Handle<TensorData> runEigenSpatial(TensorData& input,  int z, int y, int x, int stride) {
 
         Eigen::TensorMap<Eigen::Tensor<float, 3>> a (input.rawData->c_ptr(), z, y, x);
         
@@ -83,21 +83,22 @@ public:
         contract_dims[0] = Eigen::IndexPair<int>(1, 0);
 
 
-        //out_height = inputRows - kernelRowsEff + 1 = y - yk + 1
-        //out_width = inputCols - kernelColsEff + 1 = x - xk + 1
+        //out_height = (inputRows - kernelRowsEff) / stride + 1 = (y - yk) / stride + 1
+        //out_width = (inputCols - kernelColsEff) / stride  + 1 = (x - xk) / stride + 1
 
-        
+       int oy = calculateOutputDimension(y, yk, stride);
+       int ox = calculateOutputDimension(x, xk, stride);
        
         //pre_contract_dims
         Eigen::array<int, 2> pre_contract_dims;
         pre_contract_dims[0] = zk * yk * xk;
-        pre_contract_dims[1] = (y - yk + 1 ) * (x - xk + 1 );
+        pre_contract_dims[1] = (oy) * (ox);
 
         //post_contract_dims
         Eigen::array<int, 3> post_contract_dims;
         post_contract_dims[0] = nk;
-        post_contract_dims[1] = (y - yk + 1 );
-        post_contract_dims[2] = (x - xk + 1 );
+        post_contract_dims[1] = (oy);
+        post_contract_dims[2] = (ox);
 
         //kernel dims
         Eigen::array<int, 2> kernel_dims;
@@ -111,23 +112,23 @@ public:
         
         dimensions->push_back(nk);
         
-        dimensions->push_back(y - yk + 1);
+        dimensions->push_back(oy);
         
-        dimensions->push_back(x - xk + 1);
+        dimensions->push_back(ox);
 
         Handle<TensorData> out = makeObject<TensorData>(3, dimensions);
 
-        float * mempool = (float *) malloc (nk * (y - yk + 1) * (x - xk + 1) * sizeof(float));
+       float * mempool = (float *) malloc (nk * oy * ox * sizeof(float));
 
-        Eigen::TensorMap<Eigen::Tensor<float, 3>> c (mempool, nk, y - yk + 1, x - xk + 1); 
+        Eigen::TensorMap<Eigen::Tensor<float, 3>> c (mempool, nk, oy, ox); 
 
         c = b1.reshape(kernel_dims)
               .contract(
-                 a.extract_image_patches(yk, xk, 1, 1, 1, 1, 
+                 a.extract_image_patches(yk, xk, stride, stride, 1, 1, 
                                              Eigen::PADDING_VALID)
                   .reshape(pre_contract_dims), contract_dims)
               .reshape(post_contract_dims);
-                 
+
 
         /* 
         c = a.extract_image_patches(yk, xk, 1, 1, 1, 1, Eigen::PADDING_VALID)
@@ -137,31 +138,33 @@ public:
                                      .reshape(Eigen::array<int, 3>({ (x - xk + 1 ), (y - yk + 1 ), nk }));
 
         */
-        memcpy (out->rawData->c_ptr(), mempool, nk * (y - yk + 1) * (x - xk + 1) * sizeof(float));
 
-        return out;
+       memcpy (out->rawData->c_ptr(), mempool, nk * oy * ox * sizeof(float));
 
+       return out;
     }
 
     Handle<TensorData> runAtenConv2d(TensorData& input, int z, int y, int x, int stride) {
+
         //input data
         at::Tensor a = at::from_blob(input.rawData->c_ptr(), {1, z, y, x});
 
         at::Tensor b = at::from_blob(kernel->rawData->c_ptr(), {nk, zk, yk, xk});
 
-        at::Tensor bias;
+        // bias length = kernel count = nk
+        at::Tensor bias = at::zeros({nk}, at::kInt);
         //perform the convolutional operation
         auto c = at::conv2d(a, b, bias, stride);
 
         //create the output
+        int oy = calculateOutputDimension(y, yk, stride);
+        int ox = calculateOutputDimension(x, xk, stride);
         Handle<Vector<unsigned int>> dimensions = makeObject<Vector<unsigned int>>(3);
-        
+
         dimensions->push_back(nk);
-        
-        int oy = calculateOutputDimension(y, yk, stride) + 1;
+
         dimensions->push_back(oy);
 
-        int ox = calculateOutputDimension(x, xk, stride) + 1;
         dimensions->push_back(ox);
 
         Handle<TensorData> out = makeObject<TensorData>(3, dimensions);
@@ -194,7 +197,7 @@ public:
 
 
             if (conv2dMode == "eigen-spatial") {
-                return runEigenSpatial(input, z, y, x);
+                return runEigenSpatial(input, z, y, x, stride);
             } else {
                 return runAtenConv2d(input, z, y, x, stride);
             }

--- a/src/tests/source/Conv2dProjTest.cc
+++ b/src/tests/source/Conv2dProjTest.cc
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
 
   //load data
   if (addDataOrNot == true) {
-      load_rnd_img(112, 112, 3, numImages, pdbClient, dbName, img_set);
+      load_rnd_img(56, 56, 256, numImages, pdbClient, dbName, img_set);
   }
  
   //create output dataset
@@ -177,8 +177,8 @@ int main(int argc, char *argv[]) {
   pdb::Handle<pdb::Computation> imageScanner =
       pdb::makeObject<pdb::ScanUserSet<pdb::TensorData>>(dbName, img_set);
 
-  pdb::Handle<pdb::Vector<unsigned int>> dimensions = pdb::makeObject<pdb::Vector<unsigned int>>(4);
-  unsigned int x=7, y=7, z=3, n=64;
+  pdb::Handle<pdb::Vector<unsigned int>> dimensions = pdb::makeObject<pdb::Vector<unsigned int>>(3);
+  unsigned int x=1, y=1, z=256, n=128;
   dimensions->push_back(n);
   dimensions->push_back(z);
   dimensions->push_back(y);
@@ -193,8 +193,8 @@ int main(int argc, char *argv[]) {
 
 
   //create select computation
-//  pdb::Handle<pdb::Computation> select = pdb::makeObject<Conv2DSelect>(kernel, "aten-conv2d");
-  pdb::Handle<pdb::Computation> select = pdb::makeObject<Conv2DSelect>(kernel, mode);
+  // stride: 2 (across all dimensions)
+  pdb::Handle<pdb::Computation> select = pdb::makeObject<Conv2DSelect>(kernel, 2, mode);
   select->setInput(0, imageScanner);
   std::cout << "select's output type: "<< select->getOutputType() << std::endl;
   //create write computation

--- a/src/tests/source/Conv2dProjTest.cc
+++ b/src/tests/source/Conv2dProjTest.cc
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
 
   //load data
   if (addDataOrNot == true) {
-      load_rnd_img(56, 56, 256, numImages, pdbClient, dbName, img_set);
+      load_rnd_img(112, 112, 3, numImages, pdbClient, dbName, img_set);
   }
  
   //create output dataset
@@ -177,15 +177,16 @@ int main(int argc, char *argv[]) {
   pdb::Handle<pdb::Computation> imageScanner =
       pdb::makeObject<pdb::ScanUserSet<pdb::TensorData>>(dbName, img_set);
 
-  pdb::Handle<pdb::Vector<unsigned int>> dimensions = pdb::makeObject<pdb::Vector<unsigned int>>(3);
-  unsigned int x=1, y=1, z=256, n=128;
+  pdb::Handle<pdb::Vector<unsigned int>> dimensions = pdb::makeObject<pdb::Vector<unsigned int>>(4);
+  unsigned int x=7, y=7, z=3, n=64;
   dimensions->push_back(n);
   dimensions->push_back(z);
   dimensions->push_back(y);
   dimensions->push_back(x);
+
   pdb::Handle<TensorData> kernel = pdb::makeObject<TensorData>(4, dimensions);
 
-  for (unsigned int i = 0; i < n*z*y*z; i++) {
+  for (unsigned int i = 0; i < n*z*y*x; i++) {
 
      (*(kernel->rawData))[i] = 0.5;
 
@@ -193,8 +194,8 @@ int main(int argc, char *argv[]) {
 
 
   //create select computation
-  // stride: 2 (across all dimensions)
-  pdb::Handle<pdb::Computation> select = pdb::makeObject<Conv2DSelect>(kernel, 2, mode);
+  // stride (across all dimensions)
+  pdb::Handle<pdb::Computation> select = pdb::makeObject<Conv2DSelect>(kernel, mode, 1);
   select->setInput(0, imageScanner);
   std::cout << "select's output type: "<< select->getOutputType() << std::endl;
   //create write computation


### PR DESCRIPTION
1) Add stride support to runAtenConv2
2) Add stride support for Aten runEigenSpatial
3) Fix https://github.com/asu-cactus/netsdb/pull/11/files#diff-72ad71a426e37115d48eb606219887979bad2bf674c258998cda77df38c98a57R189


Tested:
1) Input: W = 112, H = 112, C = 64, N = 1, kernel: W = 1, H = 1, C = 64, count of kernels = 64, stride = 1
2) Input: W = 56, H = 56, C = 256, N = 1, kernel: W = 1, H = 1, C = 256, count of kernels = 128, stride = 2
3) Input: W = 7, H = 7, C = 512, N = 1, kernel: W = 1, H = 1, C = 512, count of kernels = 2048, stride = 1