### PR TITLE
Data Loading into netsDB

### DIFF
--- a/src/FF/headers/FFMatrixUtil.h
+++ b/src/FF/headers/FFMatrixUtil.h
@@ -36,7 +36,7 @@ void loadMatrixGeneric(pdb::PDBClient &pdbClient, pdb::String dbName,
 template <class T>
 void loadMatrixGenericFromFile(pdb::PDBClient &pdbClient, std::string path, pdb::String dbName,
                 pdb::String setName, int totalX, int totalY, int blockX,
-                int blockY, std::string &errMsg,
+                int blockY, int label_col_index, std::string &errMsg,
                 int size=128, bool partitionByCol=true);
 
 

--- a/src/builtInPDBObjects/headers/TreeResult.h
+++ b/src/builtInPDBObjects/headers/TreeResult.h
@@ -2,7 +2,7 @@
 #ifndef NETSDB_TREE_RESULT_H
 #define NETSDB_TREE_RESULT_H
 
-#define MAX_BLOCK_SIZE 275000
+#define MAX_BLOCK_SIZE 500000
 
 #include <cmath>
 #include <cstdlib>

--- a/src/tests/source/TestDecisionForest.cc
+++ b/src/tests/source/TestDecisionForest.cc
@@ -52,9 +52,9 @@ int main(int argc, char *argv[]) {
 
     bool createSet;
 
-    if ((argc <= 7)||(argc > 11)) {
+    if ((argc <= 8)||(argc > 12)) {
     
-        std::cout << "Usage: \n To load data: bin/testDecisionForest Y numInstances numFeatures batch_size isFloat[F/D] isGraphOrArray[G/A] pageSizeInMB pathToLoadDataFile(N for generating data randomly)\n To run the inference: bin/testDecisionForest N numInstances numFeatures batchSize isFloat[F/D] isGraphOrArray [G/A] pageSizeInMB pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n Example: \n bin/testDecisionForest Y 2200000 28 275000 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv\n bin/testDecisionForest N 2200000 28 275000 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
+        std::cout << "Usage: \n To load data: bin/testDecisionForest Y numInstances numFeatures batch_size label_col_index isFloat[F/D] isGraphOrArray[G/A] pageSizeInMB pathToLoadDataFile(N for generating data randomly) \n To run the inference: bin/testDecisionForest N numInstances numFeatures batchSize label_col_index isFloat[F/D] isGraphOrArray [G/A] pageSizeInMB pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n Example: \n bin/testDecisionForest Y 2200000 28 275000 0 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv\n bin/testDecisionForest N 2200000 28 275000 0 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
         exit(-1);
     }
 
@@ -62,6 +62,7 @@ int main(int argc, char *argv[]) {
     int colNum = -1;
     int block_x = -1;
     int block_y = -1;
+    int label_col_index = 0;
     bool isFloat = true;
     bool isGraph = true;
     string errMsg;
@@ -70,7 +71,7 @@ int main(int argc, char *argv[]) {
     int pageSize = 64;
     string dataFilePath = "";
 
-    if(argc >= 7) {
+    if(argc >= 8) {
 
         if(string(argv[1]).compare("Y")==0) {
             createSet = true;
@@ -83,40 +84,42 @@ int main(int argc, char *argv[]) {
         block_x = std::atoi(argv[4]); //batch size
         block_y = colNum; //numFeatures
 
-        if (string(argv[5]).compare("F")==0) {
+        label_col_index = std::atoi(argv[5]);
+
+        if (string(argv[6]).compare("F")==0) {
             isFloat = true;
         } else {
             isFloat = false; 
         }
 
-	 if (string(argv[6]).compare("G")==0) {
+	 if (string(argv[7]).compare("G")==0) {
             isGraph = true;
         } else {
             isGraph = false;
         }
     }
 
-    if (argc >= 8) {
-        pageSize = std::stoi(argv[7]);
-    }
-
     if (argc >= 9) {
-        dataFilePath = std::string(argv[8]);
+        pageSize = std::stoi(argv[8]);
     }
 
     if (argc >= 10) {
-        forestFolderPath = std::string(argv[9]);
+        dataFilePath = std::string(argv[9]);
     }
 
     if (argc >= 11) {
-        if (string(argv[10]).compare("XGBoost") == 0) {
+        forestFolderPath = std::string(argv[10]);
+    }
+
+    if (argc >= 12) {
+        if (string(argv[11]).compare("XGBoost") == 0) {
             modelType = ModelType::XGBoost;
-	} else if (string(argv[10]).compare("LightGBM") == 0) {
+	} else if (string(argv[11]).compare("LightGBM") == 0) {
             modelType = ModelType::LightGBM;
-        } else if (string(argv[10]).compare("RandomForest") == 0) {
+        } else if (string(argv[11]).compare("RandomForest") == 0) {
             modelType = ModelType::RandomForest;
         } else {
-            std::cerr << "Unsupported model type: " << argv[10] << std::endl;
+            std::cerr << "Unsupported model type: " << argv[11] << std::endl;
 	    exit(-1);
         }
     }
@@ -134,7 +137,7 @@ int main(int argc, char *argv[]) {
            if (dataFilePath.compare("N") == 0) {
 	       ff::loadMatrixGeneric<pdb::TensorBlock2D<float>>(pdbClient, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, false, false, errMsg);		   
 	   } else {
-	       ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<float>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, errMsg, 128);
+	       ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<float>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, label_col_index, errMsg, 128);
 	   }
 	}
    	else {
@@ -142,7 +145,7 @@ int main(int argc, char *argv[]) {
 	   if (dataFilePath.compare("N") == 0) {
                ff::loadMatrixGeneric<pdb::TensorBlock2D<double>>(pdbClient, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, false, false, errMsg);
            } else {
-	       ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<double>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, errMsg, 128);
+	       ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<double>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, label_col_index, errMsg, 128);
            }
 	}
     } else{

--- a/src/tests/source/TestDecisionForestWithCrossProduct.cc
+++ b/src/tests/source/TestDecisionForestWithCrossProduct.cc
@@ -99,9 +99,9 @@ int main(int argc, char *argv[]) {
 
     bool createSet;
 
-    if ((argc <= 5)||(argc > 10)) {
+    if ((argc <= 6)||(argc > 11)) {
     
-        std::cout << "Usage: \n To load data: bin/testDecisionForestWithCrossProduct Y numInstances numFeatures batch_size pageSizeInMB pathToLoadDataFile(N for generating data randomly) pathToModelFolder modelType[XGBoost/RandomForest]\n To run the inference: bin/testDecisionForestWithCrossProduct N numInstances numFeatures batchSize pageSizeInMB pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n Example: \n bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n bin/testDecisionForestWithCrossProduct N 2200000 28 275000 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
+        std::cout << "Usage: \n To load data: bin/testDecisionForestWithCrossProduct Y numInstances numFeatures batch_size label_col_index, pageSizeInMB pathToLoadDataFile(N for generating data randomly) pathToModelFolder modelType[XGBoost/RandomForest]\n To run the inference: bin/testDecisionForestWithCrossProduct N numInstances numFeatures batchSize labelColIndex pageSizeInMB pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n Example: \n bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n bin/testDecisionForestWithCrossProduct N 2200000 28 275000 0 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
         exit(-1);
     }
 
@@ -109,6 +109,7 @@ int main(int argc, char *argv[]) {
     int colNum = -1;
     int block_x = -1;
     int block_y = -1;
+    int label_col_index = 0;
     string errMsg;
     string forestFolderPath;
     ModelType modelType = ModelType::XGBoost;
@@ -116,7 +117,8 @@ int main(int argc, char *argv[]) {
     string dataFilePath = "";
     int numTrees = 0;
 
-    if(argc >= 5) {
+
+    if(argc >= 6) {
 
         if(string(argv[1]).compare("Y")==0) {
             createSet = true;
@@ -129,26 +131,28 @@ int main(int argc, char *argv[]) {
         block_x = std::atoi(argv[4]); //batch size
         block_y = colNum; //numFeatures
 
-    }
+        label_col_index = std::atoi(argv[5]);//the index of label column
 
-    if (argc >= 6) {
-        pageSize = std::stoi(argv[5]);
     }
 
     if (argc >= 7) {
-        dataFilePath = std::string(argv[6]);
+        pageSize = std::stoi(argv[6]);
     }
 
     if (argc >= 8) {
-        forestFolderPath = std::string(argv[7]);
+        dataFilePath = std::string(argv[7]);
     }
 
     if (argc >= 9) {
-        if (string(argv[8]).compare("XGBoost") == 0) {
+        forestFolderPath = std::string(argv[8]);
+    }
+
+    if (argc >= 10) {
+        if (string(argv[9]).compare("XGBoost") == 0) {
             modelType = ModelType::XGBoost;
-        } else if (string(argv[8]).compare("RandomForest") == 0) {
+        } else if (string(argv[9]).compare("RandomForest") == 0) {
             modelType = ModelType::RandomForest;
-        } else if (string(argv[8]).compare("LightGBM") == 0) {
+        } else if (string(argv[9]).compare("LightGBM") == 0) {
 	    modelType = ModelType::LightGBM;
 	} else {
             std::cerr << "Unsupported model type: " << argv[8] << std::endl;
@@ -156,8 +160,8 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (argc >= 10) {
-        numTrees = std::stoi(argv[9]);
+    if (argc >= 11) {
+        numTrees = std::stoi(argv[10]);
     }
 
 
@@ -174,7 +178,7 @@ int main(int argc, char *argv[]) {
         if (dataFilePath.compare("N") == 0) {
 	    ff::loadMatrixGeneric<pdb::TensorBlock2D<float>>(pdbClient, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, false, false, errMsg);		   
 	} else {
-	    ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<float>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, errMsg, 128);
+	    ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<float>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, label_col_index, errMsg, 128);
 	}
 
 	//create set for tree

--- a/src/tests/source/TestDecisionForestWithCrossProduct.cc
+++ b/src/tests/source/TestDecisionForestWithCrossProduct.cc
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
 
 	//create set for labels
         pdbClient.removeSet("decisionForest", "labels", errMsg);
-        pdbClient.createSet<pdb::Tree>("decisionForest", "labels",
+        pdbClient.createSet<pdb::TreeResult>("decisionForest", "labels",
                                            errMsg, 64*1024*1024, "labels",
                                            nullptr, nullptr, false);
 
@@ -209,7 +209,6 @@ int main(int argc, char *argv[]) {
 	pdb::Handle<pdb::Computation> inputTree = pdb::makeObject<pdb::ScanUserSet<Tree>>("decisionForest", "trees");
 
 
-	//if ((modelType == ModelType::XGBoost) || (modelType == ModelType::LightGBM)) {
 
             pdb::Handle<pdb::CrossProductComp> treeCrossProduct = makeObject<TreeCrossProduct>();
 


### PR DESCRIPTION
All, I've fixed the data loading into netsDB so that:

(1) It now can handle input files whose number of rows are not fully divided by the block size (blockX);

(2) It now can handle input files whose label column is not the last column. This fix requires to pass a parameter to specify the label column index.

The new command for loading data is:

`bin/testDecisionForest Y 2200000 28 275000 0 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv`

`bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_randomforest_10_8_netsdb RandomForest`

The parameter 0 specifies that the label column for this file is the column-0.

**The complete commands and outputs for Higgs dataset are:**

Please recompile with flag: #define MAX_BLOCK_SIZE 275000

_Without CrossProduct_

`scripts/cleanupNode.sh `

`./scripts/startPseudoCluster.py 8 20000`

`bin/testDecisionForest Y 2200000 28 275000 0 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv`

`bin/testDecisionForest N 2200000 28 275000 0 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_randomforest_10_8_netsdb RandomForest`


**Output:**

output count:2200000
positive count:1033098

_With CrossProduct_

`scripts/cleanupNode.sh `

`./scripts/startPseudoCluster.py 8 20000`

`bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_randomforest_10_8_netsdb RandomForest`

`bin/testDecisionForest N 2200000 28 275000 0 F A 32 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_randomforest_10_8_netsdb RandomForest`

**Output:**

total count:2200000
positive count:1033098


**The complete commands and outputs for TPCx-AI dataset are:**

Please recompile with flag: #define MAX_BLOCK_SIZE 500000

_Without CrossProduct_

`scripts/cleanupNode.sh `

`./scripts/startPseudoCluster.py 8 20000`

`bin/testDecisionForest Y 7353840 7 500000 7 F A 32 model-inference/decisionTree/experiments/dataset/tpcxai_fraud_test.csv`

`bin/testDecisionForest N 7353840 7 500000 7 F A 32 model-inference/decisionTree/experiments/dataset/tpcxai_fraud_test.csv model-inference/decisionTree/experiments/models/tpcxai_fraud_randomforest_10_8_netsdb RandomForest`

**Output**

output count:7353840
positive count:99593

_With CrossProduct_

`scripts/cleanupNode.sh `

`./scripts/startPseudoCluster.py 8 20000`

`bin/testDecisionForestWithCrossProduct Y 7353840 7 500000 7 32 model-inference/decisionTree/experiments/dataset/tpcxai_fraud_test.csv model-inference/decisionTree/experiments/models/tpcxai_fraud_randomforest_10_8_netsdb RandomForest`

`bin/testDecisionForestWithCrossProduct N 7353840 7 500000 7 32 model-inference/decisionTree/experiments/dataset/tpcxai_fraud_test.csv model-inference/decisionTree/experiments/models/tpcxai_fraud_randomforest_10_8_netsdb RandomForest 10`

**Output**

total count:7353840
positive count:99593
