### PR TITLE
Reading LightGBM from CSV and suport sparse data and regression tasks

### DIFF
--- a/model-inference/decisionTree/experiments/data_processing.py
+++ b/model-inference/decisionTree/experiments/data_processing.py
@@ -144,9 +144,7 @@ def prepare_year(dataset_folder, nrows=None):
     url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/00203/YearPredictionMSD.txt.zip'
     local_url = download_data(url, dataset_folder)
     df = pd.read_csv(local_url, dtype=np.float32, nrows=nrows, header=None)
-    df = df.astype({0: np.int8})
     return df
-
 
 def prepare_epsilon(nrows=None):
     from catboost.datasets import epsilon

--- a/model-inference/decisionTree/experiments/test_model.py
+++ b/model-inference/decisionTree/experiments/test_model.py
@@ -286,8 +286,10 @@ def test_cpu(args, features, label, sklearnmodel, config, time_consume):
     else:
         raise ValueError(f"{FRAMEWORK} is not supported.")
     if args.task_type == "classification":
+        print(f"Number of positives predictions: {sum(results)}")
         find_accuracy(FRAMEWORK, label, results)
     else:
+        print(f"Mean of all predictions: {sum(results)/len(results)}")
         find_MSE(FRAMEWORK, label, results)
     return (time_consume, conversion_time, total_framework_time, config)
 

--- a/src/FF/source/FFMatrixUtil.cc
+++ b/src/FF/source/FFMatrixUtil.cc
@@ -378,10 +378,6 @@ void loadMatrixGenericFromFile(pdb::PDBClient &pdbClient, std::string path,
                     new_pos = line.size() - 1;
                 if (colIndex != labelColIndex) {
                     std::string token = line.substr(pos, new_pos - pos);
-                    // if (token.empty())
-                    //     (*(myData->getRawDataHandle()))[ii * blockY + jj] = std::nan("");
-                    // else
-                    //     (*(myData->getRawDataHandle()))[ii * blockY + jj] = std::stod(token);
                     (*(myData->getRawDataHandle()))[ii * blockY + jj] = token.empty() ? std::nan("") : std::stod(token);
                     jj++;
                 }

--- a/src/FF/source/FFMatrixUtil.cc
+++ b/src/FF/source/FFMatrixUtil.cc
@@ -3,6 +3,8 @@
 #include "PDBClient.h"
 #include "TensorBlock2D.h"
 #include <algorithm>
+#include <fstream>
+#include <iomanip>
 #include <random>
 using namespace std;
 
@@ -208,16 +210,133 @@ void load_matrix_data(pdb::PDBClient &pdbClient, string path,
     pdbClient.flushData(errMsg);
 }
 
+template <class T>
+inline void writeMyData(const pdb::Handle<T> &myData, ofstream &outFile, int blockY) {
+
+    const auto &dataHandle = *(myData->getRawDataHandle());
+    for (std::size_t i{0}; i < dataHandle.size();) {
+        for (std::size_t index{0}; index < blockY - 1; index++) {
+            outFile << dataHandle[i++] << ',';
+        }
+        outFile << std::setprecision(0) << dataHandle[i++] << '\n';
+    }
+}
+
+template <class T>
+int allocateMyDataHelper(pdb::Handle<T> &myData, int xBlockCounter, int numXBlocks, int blockX, int blockY,
+                         int curPartitionSize, int totalY, int partitionByCol) {
+    // If this is the last XBlock, the size may not be equal to blockX,
+    // thus compute the remainder of curPartitionSize over blockX.
+    int remainder = curPartitionSize % blockX;
+    int curBlockRows = (xBlockCounter == numXBlocks - 1 && remainder != 0)
+                           ? remainder
+                           : blockX;
+    myData = pdb::makeObject<T>(xBlockCounter, 0, curBlockRows, blockY,
+                                curPartitionSize, totalY, partitionByCol);
+    myData->print();
+    std::cout << "curBlockRows=" << curBlockRows << std::endl;
+    return curBlockRows;
+}
+
+template <class T>
+int allocateMyData(pdb::PDBClient &pdbClient, pdb::Handle<pdb::Vector<pdb::Handle<T>>> &storeMatrix, pdb::Handle<T> &myData,
+                   std::string curSetName, std::string dbName, std::string &errMsg,
+                   int xBlockCounter, int numXBlocks, int blockX, int blockY, int curPartitionSize,
+                   int totalY, int partitionByCol, int size) {
+    int curBlockRows = blockX;
+    try {
+        curBlockRows = allocateMyDataHelper(myData, xBlockCounter, numXBlocks, blockX, blockY,
+                                            curPartitionSize, totalY, partitionByCol);
+    } catch (pdb::NotEnoughSpace &n) {
+        if (!pdbClient.sendData<T>(
+                pair<string, string>(curSetName, dbName), storeMatrix, errMsg)) {
+            cout << "Failed to send data to dispatcher server" << endl;
+            exit(1);
+        }
+        std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName << '\n';
+        storeMatrix.emptyOutContainingBlock();
+        pdb::makeObjectAllocatorBlock((size_t)size * (size_t)1024 * (size_t)1024, true);
+        storeMatrix = pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
+        curBlockRows = allocateMyDataHelper(myData, xBlockCounter, numXBlocks, blockX, blockY,
+                                            curPartitionSize, totalY, partitionByCol);
+    }
+    return curBlockRows;
+}
+
+template <class T>
+void pushBackMyDataToStoreMatrix(pdb::PDBClient &pdbClient, pdb::Handle<pdb::Vector<pdb::Handle<T>>> &storeMatrix, pdb::Handle<T> &myData,
+                                 std::string curSetName, std::string dbName, std::string &errMsg, int size, int total) {
+    try {
+        std::cout << "To push back a block\n";
+        storeMatrix->push_back(myData);
+        std::cout << "Push back a block\n";
+    } catch (pdb::NotEnoughSpace &n) {
+        if (!pdbClient.sendData<T>(
+                pair<string, string>(curSetName, dbName), storeMatrix, errMsg)) {
+            std::cout << "Failed to send data to dispatcher server\n";
+            exit(1);
+        }
+        std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName << '\n';
+        storeMatrix.emptyOutContainingBlock();
+        pdb::makeObjectAllocatorBlock(size * 1024 * 1024, true);
+        storeMatrix = pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
+        storeMatrix->push_back(myData);
+    }
+    std::cout << "Stored " << total << " items in total.\n";
+}
+
+template <class T>
+void processOneCsvLine(pdb::Handle<T> &myData, const std::string &line, int labelColIndex, int xBlockRowCounter, int blockY) {
+    const int startOffset = xBlockRowCounter * blockY;
+    int colIndex = 0;
+    int myDataColIndex = 0;
+    for (std::string::size_type pos = 0, newpos = 0; newpos != line.length() - 1;) {
+        newpos = line.find(',', pos);
+        if (newpos == std::string::npos) {
+            // When this is evaluated true, the loop will break
+            newpos = line.length() - 1;
+        }
+
+        if (colIndex != labelColIndex) {
+            std::string token = line.substr(pos, newpos - pos);
+            (*(myData->getRawDataHandle()))[startOffset + myDataColIndex] =
+                token.empty() ? std::nan("") : std::stod(token.data());
+            myDataColIndex++;
+        }
+        pos = newpos + 1;
+        colIndex++;
+    }
+    assert(myDataColIndex == blockY);
+}
+
+template <class T>
+void processOneSvmLine(pdb::Handle<T> &myData, const std::string &line, int labelColIndex, int xBlockRowCounter, int blockY, int curBlockRows) {
+    // Set all value default to std::nan("")
+    for (int i = 0; i < blockY * curBlockRows; i++) {
+        (*(myData->getRawDataHandle()))[i] = std::nan("");
+    }
+
+    const int startOffset = xBlockRowCounter * blockY;
+    std::string::size_type startIndex = line.find(' ') + 1;
+    std::string::size_type midIndex = 0;
+    std::string::size_type endIndex = 0;
+    do {
+        endIndex = line.find(' ', startIndex);
+        const std::string feature = line.substr(startIndex, endIndex - startIndex);
+        midIndex = feature.find(':');
+        int featureIndex = std::stoi(feature.substr(0, midIndex));
+        double featureValue = std::stod(feature.substr(midIndex + 1));
+        (*(myData->getRawDataHandle()))[startOffset + featureIndex] = featureValue;
+        startIndex = endIndex + 1;
+    } while (endIndex != std::string::npos);
+}
+
 // the number of columns in the input file should be equivalent to the blockY
 template <class T>
 void loadMatrixGenericFromFile(pdb::PDBClient &pdbClient, std::string path,
-                               pdb::String dbName, pdb::String setName, int totalX, int totalY, int blockX,
-                               int blockY, int labelColIndex,
-                               string &errMsg, int size, int numPartitions, bool partitionByCol) {
-    if (path.size() == 0) {
-        throw runtime_error("Invalid filepath: " + path);
-    }
-
+                               pdb::String dbName, pdb::String setName,
+                               int totalX, int totalY, int blockX, int blockY, int labelColIndex,
+                               std::string &errMsg, int size, int numPartitions, bool partitionByCol) {
     std::cout << "totalX=" << totalX << std::endl;
     std::cout << "totalY=" << totalY << std::endl;
     std::cout << "blockX=" << blockX << std::endl;
@@ -227,87 +346,62 @@ void loadMatrixGenericFromFile(pdb::PDBClient &pdbClient, std::string path,
 
     // open the input file
     ifstream inFile(path);
+    if (!inFile.is_open()) {
+        std::cout << __FILE__ << ": Error: Input file [" << path << "] is not found!!!\n";
+        exit(1);
+    }
+    const std::string fileSuffix = path.substr(path.rfind('.'));
+    // ofstream outFile;
+    // outFile.open("model-inference/decisionTree/experiments/dataset/HIGGS_out_test.csv");
+    // if (!outFile.is_open()) {
+    //     std::cout << __FILE__ << "Error: Output file is not found!!!\n";
+    //     exit(1);
+    // }
 
-    double val;
-    int total = 0;
     pdb::makeObjectAllocatorBlock(size * 1024 * 1024, true);
 
     int partitionSize = 0;
     int remainderPartitionSize = 0;
-
     if (numPartitions == 1) {
-
         partitionSize = totalX;
         remainderPartitionSize = totalX;
-
     } else {
-
         partitionSize = totalX / numPartitions;
         remainderPartitionSize = totalX - partitionSize * (numPartitions - 1);
     }
     std::cout << "partitionSize: " << partitionSize << "; remainderPartitionSize: " << remainderPartitionSize << std::endl;
-    int numXBlocks = 0; // ceil(totalX / (double)blockX);
-    int numYBlocks = ceil(totalY / (double)blockY);
 
+    int total = 0;
     for (int curPartitionIndex = 0; curPartitionIndex < numPartitions; curPartitionIndex++) {
+        int curPartitionSize = (curPartitionIndex == numPartitions - 1)
+                                   ? remainderPartitionSize
+                                   : partitionSize;
 
-        std::cout << "current partition index = " << curPartitionIndex << std::endl;
-
-        pdb::Handle<pdb::Vector<pdb::Handle<T>>> storeMatrix =
-            pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
-
-        bool end = false;
-        bool rollback = false;
-        std::string line;
-
-        int i = 0;
-        int j = 0;
-        int ii = 0;
-
-        int curPartitionSize = 0;
-        if (curPartitionIndex == numPartitions - 1)
-            curPartitionSize = remainderPartitionSize;
-        else
-            curPartitionSize = partitionSize;
-        numXBlocks = ceil(curPartitionSize / (double)blockX);
-        std::cout << curPartitionIndex << ":" << numXBlocks << std::endl;
-        pdb::Handle<T> myData = nullptr;
-        int curBlockRows = blockX;
+        int numXBlocks = ceil(curPartitionSize / (double)blockX);
+        std::cout << "current partition index: " << curPartitionIndex
+                  << "; number of blocks within the current partition: " << numXBlocks << '\n';
 
         std::string curSetName = std::string(setName);
-
-        if (numPartitions > 1)
+        if (numPartitions > 1) {
             curSetName = curSetName + std::to_string(curPartitionIndex);
-
+        }
         std::cout << "curSetName = " << curSetName << std::endl;
 
-        while (!end) {
-
-            if (i >= numXBlocks)
+        pdb::Handle<pdb::Vector<pdb::Handle<T>>> storeMatrix = pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
+        pdb::Handle<T> myData = nullptr;
+        std::string line;
+        int xBlockCounter = 0;
+        int xBlockRowCounter = 0;
+        while (true) {
+            if (xBlockCounter >= numXBlocks)
                 break;
-
+            // Each iteration of the while loop process one line of the input file
             if (!std::getline(inFile, line)) {
-                end = true;
                 std::cout << "We come to the end of the input file" << std::endl;
                 if (myData != nullptr) {
-                    try {
-                        storeMatrix->push_back(myData);
-                        std::cout << "Push back a block" << std::endl;
-                    } catch (pdb::NotEnoughSpace &n) {
-                        if (!pdbClient.sendData<T>(
-                                pair<string, string>(curSetName, dbName), storeMatrix, errMsg)) {
-                            cout << "Failed to send data to dispatcher server" << endl;
-                            exit(1);
-                        }
-                        std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName
-                                  << std::endl;
-                        storeMatrix.emptyOutContainingBlock();
-                        pdb::makeObjectAllocatorBlock(size * 1024 * 1024, true);
-                        storeMatrix = pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
-                        storeMatrix->push_back(myData);
-                    }
-                    std::cout << "Stored " << total << " items in total" << std::endl;
-                    i++;
+                    pushBackMyDataToStoreMatrix(pdbClient, storeMatrix, myData, curSetName, dbName, errMsg, size, total);
+                    xBlockCounter++;
+                    // writeMyData(myData, outFile, blockY);
                     myData = nullptr;
                 }
                 break;
@@ -315,124 +409,46 @@ void loadMatrixGenericFromFile(pdb::PDBClient &pdbClient, std::string path,
                 total++;
             }
 
-            try {
-                if (myData == nullptr) {
-                    if (i == numXBlocks - 1) {
-                        if (curPartitionSize % blockX == 0) {
-                            myData = pdb::makeObject<T>(i, j, blockX, blockY,
-                                                        curPartitionSize, totalY, partitionByCol);
-                            curBlockRows = blockX;
-                        } else {
-                            myData = pdb::makeObject<T>(i, j, curPartitionSize % blockX, blockY,
-                                                        curPartitionSize, totalY, partitionByCol);
-                            curBlockRows = curPartitionSize % blockX;
-                        }
-                    } else {
-
-                        myData =
-                            pdb::makeObject<T>(i, j, blockX, blockY,
-                                               curPartitionSize, totalY, partitionByCol);
-                        curBlockRows = blockX;
-                    }
-                    myData->print();
-                    std::cout << "curBlockRows=" << curBlockRows << std::endl;
-                }
-            } catch (pdb::NotEnoughSpace &n) {
-
-                if (!pdbClient.sendData<T>(
-                        pair<string, string>(curSetName, dbName), storeMatrix, errMsg)) {
-                    cout << "Failed to send data to dispatcher server" << endl;
-                    exit(1);
-                }
-                std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName
-                          << std::endl;
-                storeMatrix.emptyOutContainingBlock();
-                pdb::makeObjectAllocatorBlock((size_t)size * (size_t)1024 * (size_t)1024, true);
-                storeMatrix = pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
-                if (i == numXBlocks - 1) {
-                    if (curPartitionSize % blockX == 0) {
-                        myData = pdb::makeObject<T>(i, j, blockX, blockY,
-                                                    curPartitionSize, totalY, partitionByCol);
-                        curBlockRows = blockX;
-                    } else {
-                        myData = pdb::makeObject<T>(i, j, curPartitionSize % blockX, blockY,
-                                                    curPartitionSize, totalY, partitionByCol);
-                        curBlockRows = curPartitionSize % blockX;
-                    }
-                } else {
-
-                    myData =
-                        pdb::makeObject<T>(i, j, blockX, blockY,
-                                           curPartitionSize, totalY, partitionByCol);
-                    curBlockRows = blockX;
-                }
-                myData->print();
-                std::cout << "curBlockRows=" << curBlockRows << std::endl;
+            int curBlockRows = blockX;
+            if (myData == nullptr) {
+                curBlockRows = allocateMyData(pdbClient, storeMatrix, myData, curSetName, dbName, errMsg, xBlockCounter, numXBlocks,
+                                              blockX, blockY, curPartitionSize, totalY, partitionByCol, size);
             }
 
-            int jj = 0;
-            int colIndex = 0;
-            for (std::string::size_type pos = 0;;) {
-                std::string::size_type new_pos = line.find(',', pos);
-                if (new_pos == std::string::npos)
-                    new_pos = line.size() - 1;
-                if (colIndex != labelColIndex) {
-                    std::string token = line.substr(pos, new_pos - pos);
-                    (*(myData->getRawDataHandle()))[ii * blockY + jj] = token.empty() ? std::nan("") : std::stod(token);
-                    jj++;
-                }
-                pos = new_pos + 1;
-                colIndex++;
-                if (new_pos == line.size() - 1)
-                    break;
+            // Process one line of the input file.
+            if (fileSuffix == ".csv") {
+                processOneCsvLine(myData, line, labelColIndex, xBlockRowCounter, blockY);
+            } else if (fileSuffix == ".svm") {
+                processOneSvmLine(myData, line, labelColIndex, xBlockRowCounter, blockY, curBlockRows);
+            } else {
+                std::cout << "Cannot process file with suffix: " << fileSuffix << std::endl;
+                exit(1);
             }
 
-            assert(jj == blockY);
-
-            ii++;
-
-            if (ii == curBlockRows) {
-
-                ii = 0;
-
-                try {
-                    std::cout << "To push back a block" << std::endl;
-                    storeMatrix->push_back(myData);
-                    std::cout << "Push back a block" << std::endl;
-                } catch (pdb::NotEnoughSpace &n) {
-                    if (!pdbClient.sendData<T>(
-                            pair<string, string>(curSetName, dbName), storeMatrix, errMsg)) {
-                        cout << "Failed to send data to dispatcher server" << endl;
-                        exit(1);
-                    }
-                    std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName
-                              << std::endl;
-                    storeMatrix.emptyOutContainingBlock();
-                    pdb::makeObjectAllocatorBlock(size * 1024 * 1024, true);
-                    storeMatrix = pdb::makeObject<pdb::Vector<pdb::Handle<T>>>();
-                    storeMatrix->push_back(myData);
-                }
-                std::cout << "Stored " << total << " items in total" << std::endl;
-                i++;
+            xBlockRowCounter++;
+            if (xBlockRowCounter == curBlockRows) {
+                xBlockRowCounter = 0;
+                pushBackMyDataToStoreMatrix(pdbClient, storeMatrix, myData, curSetName, dbName, errMsg, size, total);
+                xBlockCounter++;
+                // writeMyData(myData, outFile, blockY);
                 myData = nullptr;
             }
         }
 
         if (storeMatrix->size() > 0) {
-
             if (!pdbClient.sendData<T>(
                     pair<string, string>(curSetName, dbName), storeMatrix, errMsg)) {
-                cout << "Failed to send data to dispatcher server" << endl;
+                std::cout << "Failed to send data to dispatcher server\n";
                 exit(1);
             }
-
-            std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName
-                      << std::endl;
+            std::cout << "Dispatched " << storeMatrix->size() << " blocks to " << curSetName << '\n';
         }
     }
 
     // to write back all buffered records
     pdbClient.flushData(errMsg);
+    inFile.close();
+    // outFile.close();
 }
 
 template <class T>

--- a/src/builtInPDBObjects/headers/EnsembleTreeGenericUDFDouble.h
+++ b/src/builtInPDBObjects/headers/EnsembleTreeGenericUDFDouble.h
@@ -1,79 +1,81 @@
 #ifndef ENSEMBLE_TREE_GENERIC_UDF_DOUBLE_H
 #define ENSEMBLE_TREE_GENERIC_UDF_DOUBLE_H
 
-
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <fcntl.h>
 #include <fstream>
-#include <iostream>
-#include <vector>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
-#include <string>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
-#include <algorithm>
-#include <map>
-#include <set>
-#include <cstring>
-#include <exception>
+#include <vector>
 
-#include "Object.h"
-#include "PDBVector.h"
-#include "PDBString.h"
+#include "Forest.h"
 #include "Handle.h"
-#include "TensorBlock2D.h"
 #include "Lambda.h"
 #include "LambdaCreationFunctions.h"
+#include "Object.h"
+#include "PDBString.h"
+#include "PDBVector.h"
 #include "SelectionComp.h"
-#include "Forest.h"
-
+#include "TensorBlock2D.h"
 
 // PRELOAD %EnsembleTreeGenericUDFDouble%
 
+namespace pdb {
+class EnsembleTreeGenericUDFDouble : public SelectionComp<Vector<double>, TensorBlock2D<double>> {
+  private:
+    bool hasMissing;
 
-namespace pdb 
-{
-    class EnsembleTreeGenericUDFDouble : public SelectionComp<Vector<double>, TensorBlock2D<double>>
-    {
+  public:
+    ENABLE_DEEP_COPY
 
-    public:
-        ENABLE_DEEP_COPY
+    Handle<pdb::Forest> forest;
 
-	Handle<pdb::Forest> forest;
+    EnsembleTreeGenericUDFDouble() : hasMissing{false} {}
 
-        EnsembleTreeGenericUDFDouble() {}
+    EnsembleTreeGenericUDFDouble(std::string forestPathIn, ModelType modelType, bool isClassificationTask) : hasMissing{false} {
+        forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
+    }
 
-        EnsembleTreeGenericUDFDouble(std::string forestPathIn, ModelType modelType, bool isClassificationTask)
-        {
-            forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
-        }
+    EnsembleTreeGenericUDFDouble(std::string forestPathIn, ModelType modelType, bool isClassificationTask, bool hasMissing) : hasMissing{hasMissing} {
+        forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
+    }
 
-        Lambda<bool> getSelection(Handle<TensorBlock2D<double>> checkMe) override
-        {
-            return makeLambda(checkMe,
-                              [](Handle<TensorBlock2D<double>> &checkMe)
-                              { return true; });
-        }
+    Lambda<bool> getSelection(Handle<TensorBlock2D<double>> checkMe) override {
+        return makeLambda(checkMe,
+                          [](Handle<TensorBlock2D<double>> &checkMe) { return true; });
+    }
 
-        Lambda<Handle<Vector<double>>> getProjection(Handle<TensorBlock2D<double>> in) override
-        {
+    Lambda<Handle<Vector<double>>> getProjection(Handle<TensorBlock2D<double>> in) override {
+        if (hasMissing) {
             return makeLambda(in, [this](Handle<TensorBlock2D<double>> &in) {
-
-
                 // set the output matrix
-                pdb::Handle<pdb::Vector<double>> resultMatrix = forest->predict(in);
+                pdb::Handle<pdb::Vector<double>> resultMatrix = forest->predictWithMissingValues(in);
+
+                return resultMatrix; });
+        } else {
+            return makeLambda(in, [this](Handle<TensorBlock2D<double>> &in) {
+                // set the output matrix
+                pdb::Handle<pdb::Vector<double>> resultMatrix = forest->predictWithoutMissingValues(in);
 
                 return resultMatrix; });
         }
-    };
-}
+    }
+};
+} // namespace pdb
 
 #endif

--- a/src/builtInPDBObjects/headers/EnsembleTreeGenericUDFFloat.h
+++ b/src/builtInPDBObjects/headers/EnsembleTreeGenericUDFFloat.h
@@ -47,7 +47,8 @@ class EnsembleTreeGenericUDFFloat : public SelectionComp<Vector<float>, TensorBl
 
     EnsembleTreeGenericUDFFloat() : hasMissing{false} {}
 
-    EnsembleTreeGenericUDFFloat(std::string forestPathIn, ModelType modelType, bool isClassificationTask) : hasMissing{false} {
+    EnsembleTreeGenericUDFFloat(std::string forestPathIn, ModelType modelType, bool isClassificationTask)
+        : hasMissing{false} {
         forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
     }
     EnsembleTreeGenericUDFFloat(std::string forestPathIn, ModelType modelType, bool isClassificationTask, bool hasMissing)

--- a/src/builtInPDBObjects/headers/EnsembleTreeGenericUDFFloat.h
+++ b/src/builtInPDBObjects/headers/EnsembleTreeGenericUDFFloat.h
@@ -1,79 +1,78 @@
 #ifndef ENSEMBLE_TREE_GENERIC_UDF_FLOAT_H
 #define ENSEMBLE_TREE_GENERIC_UDF_FLOAT_H
 
-
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <fcntl.h>
 #include <fstream>
-#include <iostream>
-#include <vector>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
-#include <string>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
-#include <algorithm>
-#include <map>
-#include <set>
-#include <cstring>
-#include <exception>
+#include <vector>
 
-#include "Object.h"
-#include "PDBVector.h"
-#include "PDBString.h"
+#include "Forest.h"
 #include "Handle.h"
-#include "TensorBlock2D.h"
 #include "Lambda.h"
 #include "LambdaCreationFunctions.h"
+#include "Object.h"
+#include "PDBString.h"
+#include "PDBVector.h"
 #include "SelectionComp.h"
-#include "Forest.h"
-
+#include "TensorBlock2D.h"
 
 // PRELOAD %EnsembleTreeGenericUDFFloat%
 
+namespace pdb {
+class EnsembleTreeGenericUDFFloat : public SelectionComp<Vector<float>, TensorBlock2D<float>> {
+  private:
+    bool hasMissing;
 
-namespace pdb 
-{
-    class EnsembleTreeGenericUDFFloat : public SelectionComp<Vector<float>, TensorBlock2D<float>>
-    {
+  public:
+    ENABLE_DEEP_COPY
 
-    public:
-        ENABLE_DEEP_COPY
+    Handle<pdb::Forest> forest;
 
-	Handle<pdb::Forest> forest;
+    EnsembleTreeGenericUDFFloat() : hasMissing{false} {}
 
-        EnsembleTreeGenericUDFFloat() {}
+    EnsembleTreeGenericUDFFloat(std::string forestPathIn, ModelType modelType, bool isClassificationTask) : hasMissing{false} {
+        forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
+    }
+    EnsembleTreeGenericUDFFloat(std::string forestPathIn, ModelType modelType, bool isClassificationTask, bool hasMissing)
+        : hasMissing{hasMissing} {
+        forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
+    }
+    Lambda<bool> getSelection(Handle<TensorBlock2D<float>> checkMe) override {
+        return makeLambda(checkMe,
+                          [](Handle<TensorBlock2D<float>> &checkMe) { return true; });
+    }
 
-        EnsembleTreeGenericUDFFloat(std::string forestPathIn, ModelType modelType, bool isClassificationTask)
-        {
-            forest = makeObject<pdb::Forest>(forestPathIn, modelType, isClassificationTask);
-        }
-
-        Lambda<bool> getSelection(Handle<TensorBlock2D<float>> checkMe) override
-        {
-            return makeLambda(checkMe,
-                              [](Handle<TensorBlock2D<float>> &checkMe)
-                              { return true; });
-        }
-
-        Lambda<Handle<Vector<float>>> getProjection(Handle<TensorBlock2D<float>> in) override
-        {
+    Lambda<Handle<Vector<float>>> getProjection(Handle<TensorBlock2D<float>> in) override {
+        if (hasMissing) {
             return makeLambda(in, [this](Handle<TensorBlock2D<float>> &in) {
-
-
                 // set the output matrix
-                pdb::Handle<pdb::Vector<float>> resultMatrix = forest->predict(in);
-
+                pdb::Handle<pdb::Vector<float>> resultMatrix = forest->predictWithMissingValues(in);
+                return resultMatrix; });
+        } else {
+            return makeLambda(in, [this](Handle<TensorBlock2D<float>> &in) {
+                // set the output matrix
+                pdb::Handle<pdb::Vector<float>> resultMatrix = forest->predictWithoutMissingValues(in);
                 return resultMatrix; });
         }
-    };
-}
+    }
+};
+} // namespace pdb
 
 #endif

--- a/src/builtInPDBObjects/headers/Forest.h
+++ b/src/builtInPDBObjects/headers/Forest.h
@@ -127,9 +127,17 @@ class Forest : public Object {
             return most_common(begin, end);
         }
     }
+    template <class T>
+    pdb::Handle<pdb::Vector<T>> predictWithMissingValues(Handle<TensorBlock2D<T>> &in) {
+        return predict<T, true>(in);
+    }
 
     template <class T>
-    pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in) { // TODO: Change all Double References to Float
+    pdb::Handle<pdb::Vector<T>> predictWithoutMissingValues(Handle<TensorBlock2D<T>> &in) {
+        return predict<T, false>(in);
+    }
+    template <class T, bool hasMissing>
+    inline pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in) { // TODO: Change all Double References to Float
 
         // get the input features matrix information
         uint32_t inNumRow = in->getRowNums();

--- a/src/builtInPDBObjects/headers/Forest.h
+++ b/src/builtInPDBObjects/headers/Forest.h
@@ -10,238 +10,167 @@
 
 #define MAX_NUM_TREES 1600
 
+#include "PDBClient.h"
+#include "StorageClient.h"
+#include "TensorBlock2D.h"
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <iostream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <cstring>
-#include <string>
+#include <fcntl.h>
 #include <filesystem>
+#include <fstream>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
-#include <algorithm>
-#include <map>
-#include <set>
-#include "TensorBlock2D.h"
-#include "PDBClient.h"
-#include "StorageClient.h"
+#include <vector>
 
 // PRELOAD %Forest%
 
 using std::filesystem::directory_iterator;
 
-namespace pdb
-{
+namespace pdb {
 
-    class Forest : public Object
-    {
-    public:
-        ENABLE_DEEP_COPY
+class Forest : public Object {
+  public:
+    ENABLE_DEEP_COPY
 
-        Node forest[MAX_NUM_TREES][MAX_NUM_NODES_PER_TREE];
-        int numTrees;
-        ModelType modelType;
+    Node forest[MAX_NUM_TREES][MAX_NUM_NODES_PER_TREE];
+    int numTrees;
+    ModelType modelType;
 
-        Forest() {}
+    Forest() {}
 
-        Forest(ModelType type)
-        {
-            this->modelType = type;
+    Forest(ModelType type) {
+        this->modelType = type;
+    }
+
+    Forest(std::string pathToFolder, ModelType modelType, bool isClassification) {
+        this->constructForestFromFolder(pathToFolder, modelType, isClassification);
+    }
+
+    void constructForestFromFolder(std::string pathToFolder, ModelType modelType, bool isClassification) {
+
+        std::vector<std::string> treePaths;
+
+        for (const auto &file : directory_iterator(pathToFolder)) {
+
+            treePaths.push_back(file.path());
         }
 
-	Forest(std::string pathToFolder, ModelType modelType, bool isClassification) 
-	{
-	    this->constructForestFromFolder(pathToFolder, modelType, isClassification);
-	
-	}
+        constructForestFromPaths(treePaths, modelType, isClassification);
+    }
 
-	void constructForestFromFolder(std::string pathToFolder, ModelType modelType, bool isClassification) {
-	
-	    std::vector<std::string> treePaths;
+    void constructForestFromPaths(std::vector<std::string> &treesPathIn, ModelType modelType, bool isClassification) {
 
-            for (const auto & file : directory_iterator(pathToFolder)) {
-	  
-		  treePaths.push_back(file.path());  
-	    
-	    } 
+        this->modelType = modelType;
+        this->numTrees = treesPathIn.size();
 
-	    constructForestFromPaths(treePaths, modelType, isClassification);
-	
-	}
+        for (int n = 0; n < numTrees; ++n) {
+            Tree::constructTreeFromPath(treesPathIn[n], modelType, &(forest[n][0]));
+        }
 
-        void constructForestFromPaths(std::vector<std::string> & treePathIn, ModelType modelType, bool isClassification) {
+        // STATS ABOUT THE FOREST
+        std::cout << "Number of trees in the forest: " << numTrees << std::endl;
+    }
 
-	    this->modelType = modelType;
-            this->numTrees = treePathIn.size();
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T most_common(InputIt begin, InputIt end) {
+        std::map<T, int> counts;
+        for (InputIt it = begin; it != end; ++it) {
+            if (counts.find(*it) != counts.end()) {
+                ++counts[*it];
+            } else {
+                counts[*it] = 1;
+            }
+        }
+        return std::max_element(counts.begin(), counts.end(), [](const std::pair<T, int> &pair1, const std::pair<T, int> &pair2) { return pair1.second < pair2.second; })
+            ->first;
+    }
 
-            for (int n = 0; n < numTrees; ++n)
-            {
-                std::string inputFileName = std::string(treePathIn[n]);
-                std::ifstream inputFile;
-                inputFile.open(inputFileName.data());
-                assert(inputFile.is_open());
+    // Decision of an XGBoost Tree (for class-1, not class-0): sigmoid(log(previous_tree_pred(initial_value=0)/(1-previous_tree_pred(initial_value=0))) + learning_rate*(current_tree_prob))
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T aggregate_decisions(InputIt begin, InputIt end) {
+        // Default LR Value Source: https://xgboost.readthedocs.io/en/stable/parameter.html?highlight=0.3#parameters-for-tree-booster
+        double learning_rate = 0.3;       // TODO: Hard-coding XGBoost Library default value. Change this to a parameter if modified.
+        double aggregated_decision = 0.0; // Initial Prediction is 0.5, which makes log(odds) value 0. If different, the default value changes.
+        double threshold = 0.5;
+        for (InputIt it = begin; it != end; ++it) {
+            aggregated_decision += (*it); // Should not be multiplied by Learning Rate
+        }
+        // Reference: https://stats.stackexchange.com/questions/395697/what-is-an-intuitive-interpretation-of-the-leaf-values-in-xgboost-base-learners
+        double sigmoid_of_decision = 1 / (1 + exp(-1.0 * aggregated_decision)); // Sigmoid of the aggregated decision is the final output
+        return sigmoid_of_decision > threshold ? 1.0 : 0.0;                     // Delaying Class Assignment. Class Labels as per RF Code is 1.0 and 2.0
+    }
 
-                std::string line;
-                std::vector<std::string> relationships;
-                std::vector<std::string> innerNodes;
-                std::vector<std::string> leafNodes;
-                string::size_type position;
+    // TODO: Call this function instead of Individual Compute Functions. Instantiate the Class with the Model Type
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T compute_result(InputIt begin, InputIt end) {
+        switch (modelType) {
+        case ModelType::RandomForest:
+            return most_common(begin, end);
+        case ModelType::XGBoost:
+            return aggregate_decisions(begin, end);
+        case ModelType::LightGBM:
+            return aggregate_decisions(begin, end);
+        default: // RF is default
+            return most_common(begin, end);
+        }
+    }
 
-                while (getline(inputFile, line))
-                {
-	            if ((line.size()==0) || (line.find("graph")!=std::string::npos) || (line.find("digraph Tree {")!=std::string::npos) || (line.find("node [shape=box")!=std::string::npos) || (line.find("edge [fontname=")!=std::string::npos) || (line.find("}")!=std::string::npos))
-                    {
-                        continue;
+    template <class T>
+    pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in) { // TODO: Change all Double References to Float
+
+        // get the input features matrix information
+        uint32_t inNumRow = in->getRowNums();
+        uint32_t inNumCol = in->getColNums();
+
+        T *inData = in->getValue().rawData->c_ptr();
+
+        // set the output matrix
+        pdb::Handle<pdb::Vector<T>> resultMatrix = pdb::makeObject<pdb::Vector<T>>(inNumRow, inNumRow);
+        std::vector<T> thisResultMatrix(numTrees);
+
+        T *outData = resultMatrix->c_ptr();
+
+        T inputValue;
+        Node treeNode;
+        int featureStartIndex;
+        int curIndex;
+
+        for (int i = 0; i < inNumRow; i++) {
+            featureStartIndex = i * inNumCol;
+            for (int j = 0; j < numTrees; j++) {
+                //  inference
+                //  pass the root node of the tree
+                Node *tree = forest[j];
+                treeNode = tree[0];
+                while (treeNode.isLeaf == false) {
+
+                    if (inData[featureStartIndex + treeNode.indexID] <= treeNode.returnClass) {
+                        treeNode = tree[treeNode.leftChild];
+                    } else {
+                        treeNode = tree[treeNode.rightChild];
                     }
-                    else
-                    {
-                        position = line.find("->");
-                        if (position != string::npos)
-                        {
-                            relationships.push_back(line);
-                        }
-                        else
-                        { // Find Leaf/Inner Node
-                            if ((line.find("leaf") != string::npos) || (line.find("[label=\"gini") != string::npos))
-                            {
-                                leafNodes.push_back(line);
-                            }
-                            else
-                            {
-                                innerNodes.push_back(line);
-                            }
-                        }
-                    }
                 }
-
-    		inputFile.close();
-		Tree::processInnerNodes(innerNodes, modelType, &(forest[n][0]));
-		Tree::processLeafNodes(leafNodes, modelType, &(forest[n][0]));
-		Tree::processRelationships(relationships, modelType, &(forest[n][0]));
-
+                thisResultMatrix[j] = treeNode.returnClass;
             }
-
-            // STATS ABOUT THE FOREST
-            std::cout << "Number of trees in the forest: " << numTrees << std::endl;
-	}
-
-
-        template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-        T most_common(InputIt begin, InputIt end)
-        {
-            std::map<T, int> counts;
-            for (InputIt it = begin; it != end; ++it)
-            {
-                if (counts.find(*it) != counts.end())
-                {
-                    ++counts[*it];
-                }
-                else
-                {
-                    counts[*it] = 1;
-                }
-            }
-            return std::max_element(counts.begin(), counts.end(), [](const std::pair<T, int> &pair1, const std::pair<T, int> &pair2)
-                                    { return pair1.second < pair2.second; })
-                ->first;
+            T voteResult = compute_result(thisResultMatrix.begin(), thisResultMatrix.end());
+            outData[i] = voteResult;
         }
-
-        // Decision of an XGBoost Tree (for class-1, not class-0): sigmoid(log(previous_tree_pred(initial_value=0)/(1-previous_tree_pred(initial_value=0))) + learning_rate*(current_tree_prob))
-        template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-        T aggregate_decisions(InputIt begin, InputIt end)
-        {
-            // Default LR Value Source: https://xgboost.readthedocs.io/en/stable/parameter.html?highlight=0.3#parameters-for-tree-booster
-            double learning_rate = 0.3;       // TODO: Hard-coding XGBoost Library default value. Change this to a parameter if modified.
-            double aggregated_decision = 0.0; // Initial Prediction is 0.5, which makes log(odds) value 0. If different, the default value changes.
-            double threshold = 0.5;
-            for (InputIt it = begin; it != end; ++it)
-            {
-                aggregated_decision += (*it); // Should not be multiplied by Learning Rate
-            }
-            // Reference: https://stats.stackexchange.com/questions/395697/what-is-an-intuitive-interpretation-of-the-leaf-values-in-xgboost-base-learners
-            double sigmoid_of_decision = 1 / (1 + exp(-1.0 * aggregated_decision)); // Sigmoid of the aggregated decision is the final output
-            return sigmoid_of_decision > threshold ? 1.0 : 0.0;                     // Delaying Class Assignment. Class Labels as per RF Code is 1.0 and 2.0
-        }
-
-        // TODO: Call this function instead of Individual Compute Functions. Instantiate the Class with the Model Type
-        template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-        T compute_result(InputIt begin, InputIt end)
-        {
-            switch (modelType)
-            {
-            case ModelType::RandomForest:
-                return most_common(begin, end);
-            case ModelType::XGBoost:
-                return aggregate_decisions(begin, end);
-            case ModelType::LightGBM:
-                return aggregate_decisions(begin, end);
-            default: // RF is default
-                return most_common(begin, end);
-            }
-        }
-
-        template <class T>
-        pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in)
-        {                                 // TODO: Change all Double References to Float
-
-            // get the input features matrix information
-            uint32_t inNumRow = in->getRowNums();
-	    uint32_t inNumCol = in->getColNums();
-
-            T *inData = in->getValue().rawData->c_ptr();
-
-            // set the output matrix
-            pdb::Handle<pdb::Vector<T>> resultMatrix = pdb::makeObject<pdb::Vector<T>>(inNumRow, inNumRow);
-	    std::vector<T> thisResultMatrix (numTrees);
-
-	    T * outData = resultMatrix->c_ptr();
-
-            T inputValue;
-	    Node treeNode;
-	    int featureStartIndex;
-	    int curIndex;
-
-            for (int i = 0; i < inNumRow; i++)
-            {
-		featureStartIndex = i*inNumCol;
-                for (int j = 0; j < numTrees; j++)
-                {
-                    //  inference
-                    //  pass the root node of the tree
-		    Node * tree = forest[j];
-                    treeNode = tree[0];
-                    while (treeNode.isLeaf == false)
-                    {
-
-                        if (inData[featureStartIndex + treeNode.indexID] <= treeNode.returnClass)
-                        {
-			    treeNode = tree[treeNode.leftChild];
-                        }
-                        else
-                        {
-			    treeNode = tree[treeNode.rightChild];
-                        }
-                    }
-                    thisResultMatrix[j] = treeNode.returnClass;
-                }
-                T voteResult = compute_result(thisResultMatrix.begin(), thisResultMatrix.end());
-		outData[i]=voteResult;
-	    }
-            return resultMatrix;
-        }
-    };
-}
+        return resultMatrix;
+    }
+};
+} // namespace pdb
 
 #endif // NETSDB_FOREST_H

--- a/src/builtInPDBObjects/headers/Forest.h
+++ b/src/builtInPDBObjects/headers/Forest.h
@@ -54,12 +54,12 @@ class Forest : public Object {
 
     Forest(ModelType modelType) : modelType{modelType} {}
 
-    Forest(std::string pathToFolder, ModelType modelType, bool isClassification)
+    Forest(std::string_view pathToFolder, ModelType modelType, bool isClassification)
         : modelType{modelType}, isClassification{isClassification} {
         this->constructForestFromFolder(pathToFolder, modelType);
     }
 
-    void constructForestFromFolder(std::string pathToFolder, ModelType modelType) {
+    void constructForestFromFolder(std::string_view pathToFolder, ModelType modelType) {
 
         std::vector<std::string> treePaths;
 
@@ -82,49 +82,51 @@ class Forest : public Object {
         std::cout << "Number of trees in the forest: " << numTrees << std::endl;
     }
 
-    // template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-    // T most_common(InputIt begin, InputIt end) const {
-    //     std::map<T, int> counts;
-    //     for (InputIt it = begin; it != end; ++it) {
-    //         if (counts.find(*it) != counts.end()) {
-    //             ++counts[*it];
-    //         } else {
-    //             counts[*it] = 1;
-    //         }
-    //     }
-    //     return std::max_element(counts.begin(), counts.end(), [](const std::pair<T, int> &pair1, const std::pair<T, int> &pair2) { return pair1.second < pair2.second; })
-    //         ->first;
-    // }
+#if 0
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T most_common(InputIt begin, InputIt end) const {
+        std::map<T, int> counts;
+        for (InputIt it = begin; it != end; ++it) {
+            if (counts.find(*it) != counts.end()) {
+                ++counts[*it];
+            } else {
+                counts[*it] = 1;
+            }
+        }
+        return std::max_element(counts.begin(), counts.end(), [](const std::pair<T, int> &pair1, const std::pair<T, int> &pair2) { return pair1.second < pair2.second; })
+            ->first;
+    }
 
-    // // Decision of an XGBoost Tree (for class-1, not class-0): sigmoid(log(previous_tree_pred(initial_value=0)/(1-previous_tree_pred(initial_value=0))) + learning_rate*(current_tree_prob))
-    // template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-    // T aggregate_decisions(InputIt begin, InputIt end) const {
-    //     // Default LR Value Source: https://xgboost.readthedocs.io/en/stable/parameter.html?highlight=0.3#parameters-for-tree-booster
-    //     double learning_rate = 0.3;       // TODO: Hard-coding XGBoost Library default value. Change this to a parameter if modified.
-    //     double aggregated_decision = 0.0; // Initial Prediction is 0.5, which makes log(odds) value 0. If different, the default value changes.
-    //     double threshold = 0.5;
-    //     for (InputIt it = begin; it != end; ++it) {
-    //         aggregated_decision += (*it); // Should not be multiplied by Learning Rate
-    //     }
-    //     // Reference: https://stats.stackexchange.com/questions/395697/what-is-an-intuitive-interpretation-of-the-leaf-values-in-xgboost-base-learners
-    //     double sigmoid_of_decision = 1 / (1 + exp(-1.0 * aggregated_decision)); // Sigmoid of the aggregated decision is the final output
-    //     return sigmoid_of_decision > threshold ? 1.0 : 0.0;                     // Delaying Class Assignment. Class Labels as per RF Code is 1.0 and 2.0
-    // }
+    // Decision of an XGBoost Tree (for class-1, not class-0): sigmoid(log(previous_tree_pred(initial_value=0)/(1-previous_tree_pred(initial_value=0))) + learning_rate*(current_tree_prob))
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T aggregate_decisions(InputIt begin, InputIt end) const {
+        // Default LR Value Source: https://xgboost.readthedocs.io/en/stable/parameter.html?highlight=0.3#parameters-for-tree-booster
+        double learning_rate = 0.3;       // TODO: Hard-coding XGBoost Library default value. Change this to a parameter if modified.
+        double aggregated_decision = 0.0; // Initial Prediction is 0.5, which makes log(odds) value 0. If different, the default value changes.
+        double threshold = 0.5;
+        for (InputIt it = begin; it != end; ++it) {
+            aggregated_decision += (*it); // Should not be multiplied by Learning Rate
+        }
+        // Reference: https://stats.stackexchange.com/questions/395697/what-is-an-intuitive-interpretation-of-the-leaf-values-in-xgboost-base-learners
+        double sigmoid_of_decision = 1 / (1 + exp(-1.0 * aggregated_decision)); // Sigmoid of the aggregated decision is the final output
+        return sigmoid_of_decision > threshold ? 1.0 : 0.0;                     // Delaying Class Assignment. Class Labels as per RF Code is 1.0 and 2.0
+    }
 
-    // // TODO: Call this function instead of Individual Compute Functions. Instantiate the Class with the Model Type
-    // template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-    // T compute_result(InputIt begin, InputIt end) const {
-    //     switch (modelType) {
-    //     case ModelType::RandomForest:
-    //         return most_common(begin, end);
-    //     case ModelType::XGBoost:
-    //         return aggregate_decisions(begin, end);
-    //     case ModelType::LightGBM:
-    //         return aggregate_decisions(begin, end);
-    //     default: // RF is default
-    //         return most_common(begin, end);
-    //     }
-    // }
+    // TODO: Call this function instead of Individual Compute Functions. Instantiate the Class with the Model Type
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T compute_result(InputIt begin, InputIt end) const {
+        switch (modelType) {
+        case ModelType::RandomForest:
+            return most_common(begin, end);
+        case ModelType::XGBoost:
+            return aggregate_decisions(begin, end);
+        case ModelType::LightGBM:
+            return aggregate_decisions(begin, end);
+        default: // RF is default
+            return most_common(begin, end);
+        }
+    }
+#endif
 
     template <typename T>
     pdb::Handle<pdb::Vector<T>> predictWithMissingValues(Handle<TensorBlock2D<T>> &in) const {

--- a/src/builtInPDBObjects/headers/Forest.h
+++ b/src/builtInPDBObjects/headers/Forest.h
@@ -158,15 +158,20 @@ class Forest : public Object {
                 const Node *const tree = forest[j];
                 Node treeNode = tree[0];
                 while (treeNode.isLeaf == false) {
-
-                    if (inData[featureStartIndex + treeNode.indexID] <= treeNode.returnClass) {
-                        treeNode = tree[treeNode.leftChild];
+                    T featureValue = inData[featureStartIndex + treeNode.indexID];
+                    if (hasMissing && std::isnan(featureValue)) {
+                        treeNode = (treeNode.isMissTrackLeft)
+                                       ? tree[treeNode.leftChild]
+                                       : tree[treeNode.rightChild];
                     } else {
-                        treeNode = tree[treeNode.rightChild];
+                        treeNode = (featureValue <= treeNode.threshold)
+                                       ? tree[treeNode.leftChild]
+                                       : tree[treeNode.rightChild];
                     }
                 }
-                accumulatedResult += treeNode.returnClass;
+                accumulatedResult += treeNode.leafValue;
             }
+
             if (modelType == ModelType::RandomForest) {
                 accumulatedResult /= numTrees;
             }
@@ -175,6 +180,7 @@ class Forest : public Object {
             }
             outData[i] = accumulatedResult;
         }
+
         return resultMatrix;
     }
 }; // namespace pdb

--- a/src/builtInPDBObjects/headers/Forest.h
+++ b/src/builtInPDBObjects/headers/Forest.h
@@ -48,18 +48,18 @@ class Forest : public Object {
     Node forest[MAX_NUM_TREES][MAX_NUM_NODES_PER_TREE];
     int numTrees;
     ModelType modelType;
+    bool isClassification;
 
     Forest() {}
 
-    Forest(ModelType type) {
-        this->modelType = type;
+    Forest(ModelType modelType) : modelType{modelType} {}
+
+    Forest(std::string pathToFolder, ModelType modelType, bool isClassification)
+        : modelType{modelType}, isClassification{isClassification} {
+        this->constructForestFromFolder(pathToFolder, modelType);
     }
 
-    Forest(std::string pathToFolder, ModelType modelType, bool isClassification) {
-        this->constructForestFromFolder(pathToFolder, modelType, isClassification);
-    }
-
-    void constructForestFromFolder(std::string pathToFolder, ModelType modelType, bool isClassification) {
+    void constructForestFromFolder(std::string pathToFolder, ModelType modelType) {
 
         std::vector<std::string> treePaths;
 
@@ -68,12 +68,10 @@ class Forest : public Object {
             treePaths.push_back(file.path());
         }
 
-        constructForestFromPaths(treePaths, modelType, isClassification);
+        constructForestFromPaths(treePaths, modelType);
     }
 
-    void constructForestFromPaths(std::vector<std::string> &treesPathIn, ModelType modelType, bool isClassification) {
-
-        this->modelType = modelType;
+    void constructForestFromPaths(std::vector<std::string> &treesPathIn, ModelType modelType) {
         this->numTrees = treesPathIn.size();
 
         for (int n = 0; n < numTrees; ++n) {
@@ -138,7 +136,7 @@ class Forest : public Object {
         return predict<T, false>(in);
     }
     template <class T, bool hasMissing>
-    inline pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in, bool isClassification = true) const { // TODO: Change all Double References to Float
+    inline pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in) const { // TODO: Change all Double References to Float
 
         // get the input features matrix information
         uint32_t inNumRow = in->getRowNums();

--- a/src/builtInPDBObjects/headers/ForestObjectBased.h
+++ b/src/builtInPDBObjects/headers/ForestObjectBased.h
@@ -2,219 +2,191 @@
 #ifndef NETSDB_FOREST_OBJECT_BASED_H
 #define NETSDB_FOREST_OBJECT_BASED_H
 
-
+#include "Forest.h"
+#include "PDBClient.h"
+#include "StorageClient.h"
+#include "TensorBlock2D.h"
+#include "TreeNodeObjectBased.h"
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <iostream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <cstring>
-#include <string>
+#include <fcntl.h>
 #include <filesystem>
+#include <fstream>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
-#include <algorithm>
-#include <map>
-#include <set>
-#include "TensorBlock2D.h"
-#include "PDBClient.h"
-#include "StorageClient.h"
-#include "TreeNodeObjectBased.h"
-#include "Forest.h"
+#include <vector>
 
 // PRELOAD %ForestObjectBased%
 
 using std::filesystem::directory_iterator;
 
-namespace pdb
-{
+namespace pdb {
 
-    class ForestObjectBased : public Object
-    {
-    public:
-        ENABLE_DEEP_COPY
+class ForestObjectBased : public Object {
+  public:
+    ENABLE_DEEP_COPY
 
-        Handle<Vector<Handle<TreeNodeObjectBased>>> roots = makeObject<Vector<Handle<TreeNodeObjectBased>>>();
-        int numTrees;
-        ModelType modelType;
+    Handle<Vector<Handle<TreeNodeObjectBased>>> roots = makeObject<Vector<Handle<TreeNodeObjectBased>>>();
+    int numTrees;
+    ModelType modelType;
 
-        ForestObjectBased() {}
+    ForestObjectBased() {}
 
-        ForestObjectBased(ModelType type)
-        {
-            this->modelType = type;
+    ForestObjectBased(ModelType type) {
+        this->modelType = type;
+    }
+
+    ForestObjectBased(Handle<Forest> forest) {
+        this->numTrees = forest->numTrees;
+        this->modelType = forest->modelType;
+        for (int i = 0; i < numTrees; i++) {
+            Handle<TreeNodeObjectBased> curRoot = makeObject<TreeNodeObjectBased>();
+            constructNode(curRoot, forest, i, 0);
+            roots->push_back(curRoot);
         }
+    }
 
-	ForestObjectBased(Handle<Forest> forest) 
-	{
-            this->numTrees = forest->numTrees;
-	    this->modelType = forest->modelType;
-	    for (int i = 0; i < numTrees; i++) { 
-                Handle<TreeNodeObjectBased> curRoot = makeObject<TreeNodeObjectBased>();
-		constructNode(curRoot, forest, i, 0);
-		roots->push_back(curRoot);
+    void constructNode(Handle<TreeNodeObjectBased> curNode, Handle<Forest> forest, int treeId, int nodeId) {
+        Node correspondingNode = forest->forest[treeId][nodeId];
+        curNode->returnClass = correspondingNode.threshold;
+        if (!correspondingNode.isLeaf) {
+            curNode->index = correspondingNode.indexID;
+
+            int leftChildId = correspondingNode.leftChild;
+            if (leftChildId > 0) {
+                curNode->leftChild = makeObject<TreeNodeObjectBased>();
+                constructNode(curNode->leftChild, forest, treeId, leftChildId);
+            } else {
+
+                curNode->leftChild = nullptr;
             }
-	}
 
-	void constructNode(Handle<TreeNodeObjectBased> curNode, Handle<Forest> forest, int treeId, int nodeId) {
-	       Node correspondingNode = forest->forest[treeId][nodeId];
-	       curNode->returnClass = correspondingNode.returnClass;
-	       if (!correspondingNode.isLeaf) {
-		 curNode->index = correspondingNode.indexID;
+            int rightChildId = correspondingNode.rightChild;
+            if (rightChildId > 0) {
+                curNode->rightChild = makeObject<TreeNodeObjectBased>();
+                constructNode(curNode->rightChild, forest, treeId, rightChildId);
+            } else {
 
-		 int leftChildId = correspondingNode.leftChild;
-		 if (leftChildId > 0) {
-		     curNode->leftChild = makeObject<TreeNodeObjectBased>();
-		     constructNode(curNode->leftChild, forest, treeId, leftChildId);
-		 } else {
-		 
-	             curNode->leftChild = nullptr;
-		 
-		 }
-
-		 int rightChildId = correspondingNode.rightChild;
-		 if (rightChildId > 0) {
-		     curNode->rightChild = makeObject<TreeNodeObjectBased>();
-		     constructNode(curNode->rightChild, forest, treeId, rightChildId);
-		 } else {
-		 
-		     curNode->rightChild = nullptr;
-
-		 }
-	       } else {
-	       
-	         curNode->leftChild = nullptr;
-		 curNode->rightChild = nullptr;
-	       }
-
-        }
-
-        template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-        T most_common(InputIt begin, InputIt end)
-        {
-            std::map<T, int> counts;
-            for (InputIt it = begin; it != end; ++it)
-            {
-                if (counts.find(*it) != counts.end())
-                {
-                    ++counts[*it];
-                }
-                else
-                {
-                    counts[*it] = 1;
-                }
+                curNode->rightChild = nullptr;
             }
-            return std::max_element(counts.begin(), counts.end(), [](const std::pair<T, int> &pair1, const std::pair<T, int> &pair2)
-                                    { return pair1.second < pair2.second; })
-                ->first;
-        }
+        } else {
 
-        // Decision of an XGBoost Tree (for class-1, not class-0): sigmoid(log(previous_tree_pred(initial_value=0)/(1-previous_tree_pred(initial_value=0))) + learning_rate*(current_tree_prob))
-        template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-        T aggregate_decisions(InputIt begin, InputIt end)
-        {
-            // Default LR Value Source: https://xgboost.readthedocs.io/en/stable/parameter.html?highlight=0.3#parameters-for-tree-booster
-            double learning_rate = 0.3;       // TODO: Hard-coding XGBoost Library default value. Change this to a parameter if modified.
-            double aggregated_decision = 0.0; // Initial Prediction is 0.5, which makes log(odds) value 0. If different, the default value changes.
-            double threshold = 0.5;
-            for (InputIt it = begin; it != end; ++it)
-            {
-                aggregated_decision += (*it); // Should not be multiplied by Learning Rate
-            }
-            // Reference: https://stats.stackexchange.com/questions/395697/what-is-an-intuitive-interpretation-of-the-leaf-values-in-xgboost-base-learners
-            double sigmoid_of_decision = 1 / (1 + exp(-1.0 * aggregated_decision)); // Sigmoid of the aggregated decision is the final output
-            return sigmoid_of_decision > threshold ? 2.0 : 1.0;                     // Delaying Class Assignment. Class Labels as per RF Code is 1.0 and 2.0
+            curNode->leftChild = nullptr;
+            curNode->rightChild = nullptr;
         }
+    }
 
-        // TODO: Call this function instead of Individual Compute Functions. Instantiate the Class with the Model Type
-        template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
-        T compute_result(InputIt begin, InputIt end)
-        {
-            switch (modelType)
-            {
-            case ModelType::RandomForest:
-                return most_common(begin, end);
-            case ModelType::XGBoost:
-                return aggregate_decisions(begin, end);
-                //                case ModelType::LightGBM:
-                //                    return 0.0f;
-            default: // RF is default
-                return most_common(begin, end);
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T most_common(InputIt begin, InputIt end) {
+        std::map<T, int> counts;
+        for (InputIt it = begin; it != end; ++it) {
+            if (counts.find(*it) != counts.end()) {
+                ++counts[*it];
+            } else {
+                counts[*it] = 1;
             }
         }
+        return std::max_element(counts.begin(), counts.end(), [](const std::pair<T, int> &pair1, const std::pair<T, int> &pair2) { return pair1.second < pair2.second; })
+            ->first;
+    }
 
-        void print() {
-	
-            Handle<TreeNodeObjectBased> treeNode;
-            std::cout << numTrees << " trees in total" << std::endl;
-            for (int i = 0; i < numTrees; i++)
-            {
-		std::cout << "the " << i << "-th tree:" << std::endl;
-                treeNode = (*roots)[i];
-		treeNode->print();
-            }
-	}
+    // Decision of an XGBoost Tree (for class-1, not class-0): sigmoid(log(previous_tree_pred(initial_value=0)/(1-previous_tree_pred(initial_value=0))) + learning_rate*(current_tree_prob))
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T aggregate_decisions(InputIt begin, InputIt end) {
+        // Default LR Value Source: https://xgboost.readthedocs.io/en/stable/parameter.html?highlight=0.3#parameters-for-tree-booster
+        double learning_rate = 0.3;       // TODO: Hard-coding XGBoost Library default value. Change this to a parameter if modified.
+        double aggregated_decision = 0.0; // Initial Prediction is 0.5, which makes log(odds) value 0. If different, the default value changes.
+        double threshold = 0.5;
+        for (InputIt it = begin; it != end; ++it) {
+            aggregated_decision += (*it); // Should not be multiplied by Learning Rate
+        }
+        // Reference: https://stats.stackexchange.com/questions/395697/what-is-an-intuitive-interpretation-of-the-leaf-values-in-xgboost-base-learners
+        double sigmoid_of_decision = 1 / (1 + exp(-1.0 * aggregated_decision)); // Sigmoid of the aggregated decision is the final output
+        return sigmoid_of_decision > threshold ? 2.0 : 1.0;                     // Delaying Class Assignment. Class Labels as per RF Code is 1.0 and 2.0
+    }
 
-        template <class T>
-        pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in) {
+    // TODO: Call this function instead of Individual Compute Functions. Instantiate the Class with the Model Type
+    template <class InputIt, class T = typename std::iterator_traits<InputIt>::value_type>
+    T compute_result(InputIt begin, InputIt end) {
+        switch (modelType) {
+        case ModelType::RandomForest:
+            return most_common(begin, end);
+        case ModelType::XGBoost:
+            return aggregate_decisions(begin, end);
+            //                case ModelType::LightGBM:
+            //                    return 0.0f;
+        default: // RF is default
+            return most_common(begin, end);
+        }
+    }
 
-            // get the input features matrix information
-            uint32_t inNumRow = in->getRowNums();
-	    uint32_t inNumCol = in->getColNums();
+    void print() {
 
-            T *inData = in->getValue().rawData->c_ptr();
+        Handle<TreeNodeObjectBased> treeNode;
+        std::cout << numTrees << " trees in total" << std::endl;
+        for (int i = 0; i < numTrees; i++) {
+            std::cout << "the " << i << "-th tree:" << std::endl;
+            treeNode = (*roots)[i];
+            treeNode->print();
+        }
+    }
 
-            // set the output matrix
-            pdb::Handle<pdb::Vector<T>> resultMatrix = pdb::makeObject<pdb::Vector<T>>(inNumRow, inNumRow);
-	    std::vector<T> thisResultMatrix (numTrees);
+    template <class T>
+    pdb::Handle<pdb::Vector<T>> predict(Handle<TensorBlock2D<T>> &in) {
 
-	    T * outData = resultMatrix->c_ptr();
+        // get the input features matrix information
+        uint32_t inNumRow = in->getRowNums();
+        uint32_t inNumCol = in->getColNums();
 
-            T inputValue;
-	    
-	    Handle<TreeNodeObjectBased> treeNode = nullptr;
-            int featureStartIndex;
-            int curIndex;
-            for (int i = 0; i < inNumRow; i++)
-            {
-                featureStartIndex = i*inNumCol;
-                for (int j = 0; j < numTrees; j++)
-                {
-                    treeNode = (*roots)[j];
-                    while (treeNode->leftChild != nullptr)
-                    {
-                        if (inData[featureStartIndex + treeNode->index] <= treeNode->returnClass)
-                        {
-                            treeNode = treeNode->leftChild;
-                        }
+        T *inData = in->getValue().rawData->c_ptr();
+
+        // set the output matrix
+        pdb::Handle<pdb::Vector<T>> resultMatrix = pdb::makeObject<pdb::Vector<T>>(inNumRow, inNumRow);
+        std::vector<T> thisResultMatrix(numTrees);
+
+        T *outData = resultMatrix->c_ptr();
+
+        T inputValue;
+
+        Handle<TreeNodeObjectBased> treeNode = nullptr;
+        int featureStartIndex;
+        int curIndex;
+        for (int i = 0; i < inNumRow; i++) {
+            featureStartIndex = i * inNumCol;
+            for (int j = 0; j < numTrees; j++) {
+                treeNode = (*roots)[j];
+                while (treeNode->leftChild != nullptr) {
+                    if (inData[featureStartIndex + treeNode->index] <= treeNode->returnClass) {
+                        treeNode = treeNode->leftChild;
+                    } else {
+                        if (treeNode->rightChild != nullptr)
+                            treeNode = treeNode->rightChild;
                         else
-                        {
-			    if (treeNode->rightChild != nullptr)
-                               treeNode = treeNode->rightChild;
-			    else
-			       break;
-                        }
+                            break;
                     }
-                    thisResultMatrix[j] = treeNode->returnClass;
                 }
-                T voteResult = compute_result(thisResultMatrix.begin(), thisResultMatrix.end());
-                outData[i]=voteResult;
+                thisResultMatrix[j] = treeNode->returnClass;
             }
-	    
-            return resultMatrix;
+            T voteResult = compute_result(thisResultMatrix.begin(), thisResultMatrix.end());
+            outData[i] = voteResult;
         }
-    };
-}
+
+        return resultMatrix;
+    }
+};
+} // namespace pdb
 
 #endif // NETSDB_FOREST_OBJECT_BASED_H

--- a/src/builtInPDBObjects/headers/ForestObjectBased.h
+++ b/src/builtInPDBObjects/headers/ForestObjectBased.h
@@ -61,7 +61,7 @@ class ForestObjectBased : public Object {
 
     void constructNode(Handle<TreeNodeObjectBased> curNode, Handle<Forest> forest, int treeId, int nodeId) {
         Node correspondingNode = forest->forest[treeId][nodeId];
-        curNode->returnClass = correspondingNode.threshold;
+        curNode->threshold = correspondingNode.threshold;
         if (!correspondingNode.isLeaf) {
             curNode->index = correspondingNode.indexID;
 
@@ -169,7 +169,7 @@ class ForestObjectBased : public Object {
             for (int j = 0; j < numTrees; j++) {
                 treeNode = (*roots)[j];
                 while (treeNode->leftChild != nullptr) {
-                    if (inData[featureStartIndex + treeNode->index] <= treeNode->returnClass) {
+                    if (inData[featureStartIndex + treeNode->index] <= treeNode->threshold) {
                         treeNode = treeNode->leftChild;
                     } else {
                         if (treeNode->rightChild != nullptr)
@@ -178,7 +178,7 @@ class ForestObjectBased : public Object {
                             break;
                     }
                 }
-                thisResultMatrix[j] = treeNode->returnClass;
+                thisResultMatrix[j] = treeNode->leafValue;
             }
             T voteResult = compute_result(thisResultMatrix.begin(), thisResultMatrix.end());
             outData[i] = voteResult;

--- a/src/builtInPDBObjects/headers/Tree.h
+++ b/src/builtInPDBObjects/headers/Tree.h
@@ -36,7 +36,22 @@
 using std::filesystem::directory_iterator;
 
 namespace pdb {
+
 class Tree : public Object {
+  private:
+    inline static std::array<std::string, 15> parseLGBMOneCsvLine(const std::string &line) {
+        std::array<std::string, 15> fields;
+        int findEndPosition{0};
+        int findStartPosition{0};
+        for (int i{0}; i < 14; ++i) {
+            findEndPosition = line.find(",", findStartPosition);
+            fields[i] = line.substr(findStartPosition, findEndPosition - findStartPosition);
+            findStartPosition = findEndPosition + 1;
+        }
+        fields[14] = line.substr(findStartPosition);
+        return fields;
+    }
+
   public:
     Node tree[MAX_NUM_NODES_PER_TREE];
 
@@ -49,7 +64,7 @@ class Tree : public Object {
     Tree(int treeId, std::string treePath, ModelType modelType) {
         this->treeId = treeId;
         this->modelType = modelType;
-        this->constructTreeFromPath(treePath, modelType);
+        this->constructTreeFromPath(treePath, modelType, this->tree);
     }
 
     void setUpAndCopyFrom(void *target, void *source) const override {
@@ -83,7 +98,7 @@ class Tree : public Object {
 
         for (int i = 0; i < innerNodes.size(); ++i) {
             // Construct Inner Nodes
-            string currentLine = innerNodes[i];
+            const string &currentLine = innerNodes[i];
             int nodeID;
             int indexID;
             float returnClass;
@@ -100,6 +115,7 @@ class Tree : public Object {
                 if ((findStartPosition = currentLine.find("<=")) != string::npos && (findEndPosition = currentLine.find_first_of("\\ngini")) != string::npos) {
                     returnClass = std::stod(currentLine.substr(findStartPosition + 3, findEndPosition - findStartPosition - 3));
                 }
+                tree[nodeID].isMissTrackLeft = false; // Doesn't matter to RandomForest
             } else if (modelType == ModelType::XGBoost) {
                 if ((findEndPosition = currentLine.find_first_of("[ label")) != string::npos) {
                     nodeID = std::stoi(currentLine.substr(4, findEndPosition - 1 - 4));
@@ -110,7 +126,14 @@ class Tree : public Object {
                 if ((findStartPosition = currentLine.find("<")) != string::npos && (findEndPosition = currentLine.find_first_of("]")) != string::npos) {
                     returnClass = std::stod(currentLine.substr(findStartPosition + 1, findEndPosition - findStartPosition - 1));
                 }
-            } else {
+                tree[nodeID].isMissTrackLeft = false;
+            } else { // modelType == ModelType::LightGBM
+#if 1
+                auto fields = parseLGBMOneCsvLine(currentLine);
+                nodeID = std::stoi(fields[2].substr(3));
+                indexID = std::stoi(fields[6].substr(7));
+                returnClass = std::stod(fields[12]);
+#else
 
                 if (((findStartPosition = currentLine.find_first_of("split")) != string::npos) && ((findEndPosition = currentLine.find_first_of("[label=<<B>")) != string::npos)) {
                     nodeID = std::stoi(currentLine.substr(findStartPosition + 5, findEndPosition - 1 - findStartPosition - 5));
@@ -131,13 +154,15 @@ class Tree : public Object {
                 if ((findStartPosition = currentLine.find("&#8804;<B>")) != string::npos && (findEndPosition = currentLine.find_first_of("</B>> fillcolor=")) != string::npos) {
                     returnClass = std::stod(currentLine.substr(findStartPosition + 10, findEndPosition - findStartPosition - 10));
                 }
+
+#endif
+                tree[nodeID].isMissTrackLeft = true;
             }
             tree[nodeID].indexID = indexID;
             tree[nodeID].isLeaf = false;
             tree[nodeID].leftChild = -1;
             tree[nodeID].rightChild = -1;
             tree[nodeID].returnClass = returnClass;
-            tree[nodeID].isMissTrackLeft = true;
         }
     }
 
@@ -148,7 +173,7 @@ class Tree : public Object {
 
         for (int i = 0; i < leafNodes.size(); ++i) {
             // Construct Leaf Nodes
-            string currentLine = leafNodes[i];
+            const string &currentLine = leafNodes[i];
 
             int nodeID;
             float returnClass = -1.0f;
@@ -170,8 +195,12 @@ class Tree : public Object {
                     returnClass = std::stod(currentLine.substr(findStartPosition + 5, findEndPosition - 3 - findStartPosition - 5));
                 }
 
-            } else {
-
+            } else { // modelType == ModelType::LightGBM
+#if 1
+                auto fields = parseLGBMOneCsvLine(currentLine);
+                nodeID = std::stoi(fields[2].substr(3));
+                returnClass = std::stod(fields[12]);
+#else
                 if (((findStartPosition = currentLine.find_first_of("leaf")) != string::npos) && ((findEndPosition = currentLine.find_first_of("[")) != string::npos)) {
                     nodeID = std::stoi(currentLine.substr(findStartPosition + 4, findEndPosition - 1 - findStartPosition - 4));
                 }
@@ -179,16 +208,16 @@ class Tree : public Object {
                 if ((findStartPosition = currentLine.find(": <B>")) != string::npos && (findEndPosition = currentLine.find("</B>>]")) != string::npos) {
                     returnClass = std::stod(currentLine.substr(findStartPosition + 5, findEndPosition - findStartPosition - 5));
                 }
-            }
-            if (modelType == ModelType::LightGBM) {
+#endif
                 nodeID = nodeID + MAX_NUM_NODES_PER_TREE / 2;
             }
+
             tree[nodeID].indexID = -1;
             tree[nodeID].isLeaf = true;
             tree[nodeID].leftChild = -1;
             tree[nodeID].rightChild = -1;
             tree[nodeID].returnClass = returnClass;
-            tree[nodeID].isMissTrackLeft = true;
+            tree[nodeID].isMissTrackLeft = true; // Doesn't matter to leave nodes
         }
     }
 
@@ -200,10 +229,9 @@ class Tree : public Object {
 
         for (int i = 0; i < relationships.size(); ++i) {
             // Construct Directed Edges between Nodes
+            const std::string &currentLine = relationships[i];
             int parentNodeID;
             int childNodeID;
-            std::string currentLine = relationships[i];
-            bool isChildLeaf;
 
             if (modelType == ModelType::RandomForest) {
                 if ((findMidPosition = currentLine.find_first_of("->")) != std::string::npos) {
@@ -234,8 +262,28 @@ class Tree : public Object {
                 if (currentLine.find("no, missing") != std::string::npos) {
                     tree[parentNodeID].isMissTrackLeft = false; // yes corresponds to left, no corresponds to right
                 }
+            } else { // modelType == ModelType::LightGBM
+#if 1
+                auto fields = parseLGBMOneCsvLine(currentLine);
+                parentNodeID = std::stoi(fields[2].substr(3));
+                const std::string leftChildString = fields[3];
+                const std::string rightChildString = fields[4];
 
-            } else {
+                if (!leftChildString.empty()) {
+                    tree[parentNodeID].leftChild = std::stoi(leftChildString.substr(3));
+                    if (bool isLeftChildLeaf = (leftChildString[2] == 'L'); isLeftChildLeaf) {
+                        tree[parentNodeID].leftChild += MAX_NUM_NODES_PER_TREE / 2;
+                    }
+                }
+
+                if (!rightChildString.empty()) {
+                    tree[parentNodeID].rightChild = std::stoi(rightChildString.substr(3));
+                    if (bool isRighChildLeaf = (rightChildString[2] == 'L'); isRighChildLeaf) {
+                        tree[parentNodeID].rightChild += MAX_NUM_NODES_PER_TREE / 2;
+                    }
+                }
+
+#else
 
                 if (((findStartPosition = currentLine.find_first_of("split")) != std::string::npos) && ((findMidPosition = currentLine.find_first_of("->")) != std::string::npos)) {
 
@@ -249,20 +297,37 @@ class Tree : public Object {
                         childNodeID = std::stoi(currentLine.substr(findMidPosition + 8, findEndPosition - 1 - findMidPosition - 8));
                     }
                 }
+#endif
             }
 
-            if (tree[parentNodeID].leftChild == -1) {
-                tree[parentNodeID].leftChild = childNodeID;
-            } else if (tree[parentNodeID].rightChild == -1) {
-                tree[parentNodeID].rightChild = childNodeID;
-            } else {
-
-                std::cout << "Error in parsing trees: children nodes were updated again: " << parentNodeID << "->" << childNodeID << std::endl;
+            if (modelType != ModelType::LightGBM) {
+                // This if statement should be deleted if the older version of parsing LightGBM is used.
+                if (tree[parentNodeID].leftChild == -1) {
+                    tree[parentNodeID].leftChild = childNodeID;
+                } else if (tree[parentNodeID].rightChild == -1) {
+                    tree[parentNodeID].rightChild = childNodeID;
+                } else {
+                    std::cout << "Error in parsing trees: children nodes were updated again: " << parentNodeID << "->" << childNodeID << std::endl;
+                }
             }
         }
     }
 
-    void constructTreeFromPath(std::string &treePathIn, ModelType modelType) {
+    static void constructTreeFromPath(std::string &treePathIn, ModelType modelType, Node *tree) {
+        std::vector<std::string> relationships;
+        std::vector<std::string> innerNodes;
+        std::vector<std::string> leafNodes;
+        constructTreeFromPathHelper(treePathIn, modelType, relationships, innerNodes, leafNodes);
+        processInnerNodes(innerNodes, modelType, tree);
+        processLeafNodes(leafNodes, modelType, tree);
+        processRelationships(relationships, modelType, tree);
+    }
+    static void constructTreeFromPathHelper(
+        std::string &treePathIn,
+        ModelType modelType,
+        std::vector<std::string> &relationships,
+        std::vector<std::string> &innerNodes,
+        std::vector<std::string> &leafNodes) {
 
         std::string inputFileName = treePathIn;
         std::ifstream inputFile;
@@ -270,20 +335,29 @@ class Tree : public Object {
         assert(inputFile.is_open());
 
         std::string line;
-        std::vector<std::string> relationships;
-        std::vector<std::string> innerNodes;
-        std::vector<std::string> leafNodes;
         string::size_type position;
 
-        while (getline(inputFile, line)) {
-            if ((line.size() == 0) || (line.find("graph") != std::string::npos) || (line.find("digraph Tree {") != std::string::npos) || (line.find("node [shape=box") != std::string::npos) || (line.find("edge [fontname=") != std::string::npos) || (line.find("}") != std::string::npos)) {
-                continue;
-            } else {
-                position = line.find("->");
-                if (position != string::npos) {
+        if (inputFileName.find("lightgbm") != std::string::npos) {
+            getline(inputFile, line); // Skip header
+            while (getline(inputFile, line)) {
+                if (line.find(",,,") != std::string::npos) { // Leaf nodes have many empty entries
+                    leafNodes.push_back((line));
+                } else { // Lines for inner nodes also contain full information of relations
+                    innerNodes.push_back(line);
                     relationships.push_back(line);
-                } else { // Find Leaf/Inner Node
-                    if ((line.find("leaf") != string::npos) || (line.find("[label=\"gini") != string::npos)) {
+                }
+            }
+        } else { // XGBoost and RandomForest
+            while (getline(inputFile, line)) {
+                if ((line.size() == 0) || (line.find("graph") != std::string::npos) ||
+                    (line.find("digraph Tree {") != std::string::npos) || (line.find("node [shape=box") != std::string::npos) ||
+                    (line.find("edge [fontname=") != std::string::npos) || (line.find("}") != std::string::npos)) {
+                    continue;
+                } else {
+                    position = line.find("->");
+                    if (position != string::npos) {
+                        relationships.push_back(line);
+                    } else if ((line.find("leaf") != string::npos) || (line.find("[label=\"gini") != string::npos)) {
                         leafNodes.push_back(line);
                     } else {
                         innerNodes.push_back(line);
@@ -293,9 +367,6 @@ class Tree : public Object {
         }
 
         inputFile.close();
-        processInnerNodes(innerNodes, modelType, this->tree);
-        processLeafNodes(leafNodes, modelType, this->tree);
-        processRelationships(relationships, modelType, this->tree);
     }
 
     pdb::Handle<TreeResult> predict(Handle<TensorBlock2D<float>> &in) { // TODO: Change all Double References to Float
@@ -343,7 +414,7 @@ class Tree : public Object {
         }
         return resultMatrix;
     }
-};
+}; // Tree
 } // namespace pdb
 
 #endif // NETSDB_TREE_H

--- a/src/builtInPDBObjects/headers/Tree.h
+++ b/src/builtInPDBObjects/headers/Tree.h
@@ -369,7 +369,16 @@ class Tree : public Object {
         inputFile.close();
     }
 
-    pdb::Handle<TreeResult> predict(Handle<TensorBlock2D<float>> &in) { // TODO: Change all Double References to Float
+    pdb::Handle<TreeResult> predictWithMissingValues(Handle<TensorBlock2D<float>> &in) {
+        return predict<true>(in);
+    }
+
+    pdb::Handle<TreeResult> predictWithoutMissingValues(Handle<TensorBlock2D<float>> &in) {
+        return predict<false>(in);
+    }
+
+    template <bool hasMissing>
+    inline pdb::Handle<TreeResult> predict(Handle<TensorBlock2D<float>> &in) { // TODO: Change all Double References to Float
         // get the input features matrix information
         uint32_t rowIndex = in->getBlockRowIndex();
         int numRows = in->getRowNums();
@@ -398,7 +407,7 @@ class Tree : public Object {
                 while (tree[curIndex].isLeaf == false) {
                     // When feature value is missing
                     const double featureValue = inData[featureStartIndex + tree[curIndex].indexID];
-                    if (std::isnan(featureValue)) {
+                    if (hasMissing && std::isnan(featureValue)) {
                         curIndex = tree[curIndex].isMissTrackLeft ? tree[curIndex].leftChild : tree[curIndex].rightChild;
                         continue;
                     }

--- a/src/builtInPDBObjects/headers/Tree.h
+++ b/src/builtInPDBObjects/headers/Tree.h
@@ -41,9 +41,9 @@ class Tree : public Object {
   private:
     inline static std::array<std::string, 15> parseLGBMOneCsvLine(const std::string &line) {
         std::array<std::string, 15> fields;
-        int findEndPosition{0};
-        int findStartPosition{0};
-        for (int i{0}; i < 14; ++i) {
+        int findEndPosition = 0;
+        int findStartPosition = 0;
+        for (int i = 0; i < 14; ++i) {
             findEndPosition = line.find(",", findStartPosition);
             fields[i] = line.substr(findStartPosition, findEndPosition - findStartPosition);
             findStartPosition = findEndPosition + 1;
@@ -61,7 +61,7 @@ class Tree : public Object {
 
     ModelType modelType;
 
-    Tree(int treeId, std::string treePath, ModelType modelType)
+    Tree(int treeId, std::string_view treePath, ModelType modelType)
         : treeId{treeId}, modelType{modelType} {
         this->constructTreeFromPath(treePath, modelType, this->tree);
     }
@@ -387,7 +387,7 @@ class Tree : public Object {
         }
     }
 
-    static void constructTreeFromPath(std::string &treePathIn, ModelType modelType, Node *tree) {
+    static void constructTreeFromPath(std::string_view treePathIn, ModelType modelType, Node *tree) {
         std::vector<std::string> relationships;
         std::vector<std::string> innerNodes;
         std::vector<std::string> leafNodes;
@@ -397,15 +397,14 @@ class Tree : public Object {
         processRelationships(relationships, modelType, tree);
     }
     static void constructTreeFromPathHelper(
-        std::string &treePathIn,
+        std::string_view treePathIn,
         ModelType modelType,
         std::vector<std::string> &relationships,
         std::vector<std::string> &innerNodes,
         std::vector<std::string> &leafNodes) {
 
-        std::string inputFileName = treePathIn;
         std::ifstream inputFile;
-        inputFile.open(inputFileName.data());
+        inputFile.open(treePathIn.data());
         assert(inputFile.is_open());
 
         std::string line;

--- a/src/builtInPDBObjects/headers/Tree.h
+++ b/src/builtInPDBObjects/headers/Tree.h
@@ -60,10 +60,10 @@ class Tree : public Object {
     int treeId;
 
     ModelType modelType;
+    bool isClassification;
 
-    Tree(int treeId, std::string treePath, ModelType modelType) {
-        this->treeId = treeId;
-        this->modelType = modelType;
+    Tree(int treeId, std::string treePath, ModelType modelType, bool isClassification)
+        : treeId{treeId}, modelType{modelType}, isClassification{isClassification} {
         this->constructTreeFromPath(treePath, modelType, this->tree);
     }
 
@@ -396,7 +396,7 @@ class Tree : public Object {
         float *inData = in->getValue().rawData->c_ptr();
 
         // set the output matrix
-        pdb::Handle<TreeResult> resultMatrix = pdb::makeObject<TreeResult>(treeId, rowIndex, numRows, modelType);
+        pdb::Handle<TreeResult> resultMatrix = pdb::makeObject<TreeResult>(treeId, rowIndex, numRows, modelType, isClassification);
 
         float *outData = resultMatrix->data->c_ptr();
 

--- a/src/builtInPDBObjects/headers/Tree.h
+++ b/src/builtInPDBObjects/headers/Tree.h
@@ -104,7 +104,8 @@ class Tree : public Object {
 
             // to get nodeID
             if (modelType == ModelType::RandomForest) {
-                if ((findEndPosition = currentLine.find_first_of("[label")) != string::npos) {
+                if ((findEndPosition = currentLine.find("[label")) != string::npos) {
+                    // std::cout << "nodeID==" << currentLine.substr(0, findEndPosition - 1) << '\n';
                     nodeID = std::stoi(currentLine.substr(0, findEndPosition - 1));
                 } else {
                     std::cout << "Error in extracting inner node nodeID\n";
@@ -112,6 +113,7 @@ class Tree : public Object {
                 }
 
                 if ((findStartPosition = currentLine.find("X[")) != string::npos && (findEndPosition = currentLine.find("] <=")) != string::npos) {
+                    // std::cout << "indexID==" << currentLine.substr(findStartPosition + 2, findEndPosition - findStartPosition - 2) << '\n';
                     indexID = std::stoi(currentLine.substr(findStartPosition + 2, findEndPosition - findStartPosition - 2));
                 } else {
                     std::cout << "Error in extracting inner node indexID\n";
@@ -119,9 +121,13 @@ class Tree : public Object {
                 }
 
                 findStartPosition = currentLine.find("<=");
-                if (findStartPosition != string::npos && (findEndPosition = currentLine.find_first_of("\\ngini")) != string::npos) {
+                if (findStartPosition != string::npos && (findEndPosition = currentLine.find("\\ngini")) != string::npos) {
+                    // For Classifiers
+                    // std::cout << "threshold==" << currentLine.substr(findStartPosition + 3, findEndPosition - findStartPosition - 3) << '\n';
                     threshold = std::stod(currentLine.substr(findStartPosition + 3, findEndPosition - findStartPosition - 3));
-                } else if (findStartPosition != string::npos && (findEndPosition = currentLine.find_first_of("\\nmse")) != string::npos) {
+                } else if (findStartPosition != string::npos && (findEndPosition = currentLine.find("\\nmse")) != string::npos) {
+                    // For Regressors
+                    // std::cout << "threshold==" << currentLine.substr(findStartPosition + 3, findEndPosition - findStartPosition - 3) << '\n';
                     threshold = std::stod(currentLine.substr(findStartPosition + 3, findEndPosition - findStartPosition - 3));
                 } else {
                     std::cout << "Error in extracting inner node threshold\n";
@@ -130,7 +136,8 @@ class Tree : public Object {
 
                 tree[nodeID].isMissTrackLeft = false; // Doesn't matter to RandomForest
             } else if (modelType == ModelType::XGBoost) {
-                if ((findEndPosition = currentLine.find_first_of("[ label")) != string::npos) {
+                if ((findEndPosition = currentLine.find("[ label")) != string::npos) {
+                    // std::cout << "nodeID==" << currentLine.substr(4, findEndPosition - 1 - 4) << '\n';
                     nodeID = std::stoi(currentLine.substr(4, findEndPosition - 1 - 4));
                 } else {
                     std::cout << "Error in extracting inner node nodeID\n";
@@ -138,13 +145,15 @@ class Tree : public Object {
                 }
 
                 if ((findStartPosition = currentLine.find("f")) != string::npos && (findEndPosition = currentLine.find("<")) != string::npos) {
+                    // std::cout << "indexID==" << currentLine.substr(findStartPosition + 1, findEndPosition - findStartPosition - 1) << '\n';
                     indexID = std::stoi(currentLine.substr(findStartPosition + 1, findEndPosition - findStartPosition - 1));
                 } else {
                     std::cout << "Error in extracting inner node indexID\n";
                     exit(1);
                 }
 
-                if ((findStartPosition = currentLine.find("<")) != string::npos && (findEndPosition = currentLine.find_first_of("\" ]")) != string::npos) {
+                if ((findStartPosition = currentLine.find("<")) != string::npos && (findEndPosition = currentLine.find("\" ]")) != string::npos) {
+                    // std::cout << "threshold==" << currentLine.substr(findStartPosition + 1, findEndPosition - findStartPosition - 1) << '\n';
                     threshold = std::stod(currentLine.substr(findStartPosition + 1, findEndPosition - findStartPosition - 1));
                 } else {
                     std::cout << "Error in extracting inner node threshold\n";
@@ -202,8 +211,9 @@ class Tree : public Object {
             int nodeID;
             float leafValue = -1.0f;
             if (modelType == ModelType::RandomForest) {
-                if ((findEndPosition = currentLine.find_first_of("[label=\"gini")) != string::npos ||
-                    (findEndPosition = currentLine.find_first_of("[label=\"mse")) != string::npos) {
+                if ((findEndPosition = currentLine.find("[label=\"gini")) != string::npos ||
+                    (findEndPosition = currentLine.find("[label=\"mse")) != string::npos) {
+                    // std::cout << "nodeID in leaf==" << currentLine.substr(0, findEndPosition - 1) << '\n';
                     nodeID = std::stoi(currentLine.substr(0, findEndPosition - 1));
                 } else {
                     std::cout << "Error in extracting leaf node nodeID\n";
@@ -211,12 +221,16 @@ class Tree : public Object {
                 }
 #if 1
                 if ((findStartPosition = currentLine.find("value = [")) != string::npos && (findEndPosition = currentLine.find("]\\nclass")) != string::npos) {
+                    // For classifiers
+                    // std::cout << "leafValue from pairs in leaf==" << currentLine.substr(findStartPosition + 9, findEndPosition - findStartPosition - 9) << '\n';
                     const std::string pairs = currentLine.substr(findStartPosition + 9, findEndPosition - findStartPosition - 9);
                     findMidPosition = pairs.find(", ");
                     const int classZeroCounts = std::stoi(pairs.substr(0, findMidPosition));
                     const int classOneCounts = std::stoi(pairs.substr(findMidPosition + 2));
                     leafValue = classOneCounts / static_cast<float>(classZeroCounts + classOneCounts);
                 } else if ((findStartPosition = currentLine.find("value = ")) != string::npos || (findEndPosition = currentLine.find("\"]")) != string::npos) {
+                    // For Regressors
+                    // std::cout << "leafValue from pairs in leaf==" << currentLine.substr(findStartPosition + 8, findEndPosition - findStartPosition - 8) << '\n';
                     leafValue = std::stof(currentLine.substr(findStartPosition + 8, findEndPosition - findStartPosition - 8));
                 } else {
                     std::cout << "Error in extracting leaf node leafValue\n";
@@ -230,7 +244,8 @@ class Tree : public Object {
                 }
 #endif
             } else if (modelType == ModelType::XGBoost) {
-                if ((findEndPosition = currentLine.find_first_of("[")) != string::npos) {
+                if ((findEndPosition = currentLine.find("[")) != string::npos) {
+                    // std::cout << "nodeID in leaf==" << currentLine.substr(4, findEndPosition - 1 - 4) << '\n';
                     nodeID = std::stoi(currentLine.substr(4, findEndPosition - 1 - 4));
                 } else {
                     std::cout << "Error in extracting leaf node nodeID\n";
@@ -239,6 +254,7 @@ class Tree : public Object {
 
                 // Output Class of XGBoost always a Double/Float. ProbabilityValue for Classification, ResultValue for Regression
                 if ((findStartPosition = currentLine.find("leaf=")) != string::npos && (findEndPosition = currentLine.find("\" ]")) != string::npos) {
+                    // std::cout << "leafValue in leaf==" << currentLine.substr(findStartPosition + 5, findEndPosition - 3 - findStartPosition - 5) << '\n';
                     leafValue = std::stod(currentLine.substr(findStartPosition + 5, findEndPosition - 3 - findStartPosition - 5));
                 } else {
                     std::cout << "Error in extracting leaf node leafValue\n";
@@ -283,7 +299,8 @@ class Tree : public Object {
             int childNodeID;
 
             if (modelType == ModelType::RandomForest) {
-                if ((findMidPosition = currentLine.find_first_of("->")) != std::string::npos) {
+                if ((findMidPosition = currentLine.find("->")) != std::string::npos) {
+                    // std::cout << "parentNodeID==" << currentLine.substr(0, findMidPosition - 1) << '\n';
                     parentNodeID = std::stoi(currentLine.substr(0, findMidPosition - 1));
                 } else {
                     std::cout << "Error in extracting parentNodeID\n";
@@ -291,7 +308,8 @@ class Tree : public Object {
                 }
 
                 std::string endPositionStr = (parentNodeID == 0) ? "[label" : ";";
-                if ((findEndPosition = currentLine.find_first_of(endPositionStr)) != std::string::npos) {
+                if ((findEndPosition = currentLine.find(endPositionStr)) != std::string::npos) {
+                    // std::cout << "childNodeID==" << currentLine.substr(findMidPosition + 3, findEndPosition - 1 - findMidPosition - 3) << '\n';
                     childNodeID = std::stoi(currentLine.substr(findMidPosition + 3, findEndPosition - 1 - findMidPosition - 3));
                 } else {
                     std::cout << "Error in extracting childNodeID\n";
@@ -299,14 +317,16 @@ class Tree : public Object {
                 }
 
             } else if (modelType == ModelType::XGBoost) {
-                if ((findMidPosition = currentLine.find_first_of("->")) != std::string::npos) {
+                if ((findMidPosition = currentLine.find("->")) != std::string::npos) {
+                    // std::cout << "parentNodeID==" << currentLine.substr(4, findMidPosition - 1 - 4) << '\n';
                     parentNodeID = std::stoi(currentLine.substr(4, findMidPosition - 1 - 4));
                 } else {
                     std::cout << "Error in extracting parentNodeID\n";
                     exit(1);
                 }
 
-                if ((findEndPosition = currentLine.find_first_of("[")) != std::string::npos) {
+                if ((findEndPosition = currentLine.find("[")) != std::string::npos) {
+                    // std::cout << "childNodeID==" << currentLine.substr(findMidPosition + 3, findEndPosition - 1 - findMidPosition - 3) << '\n';
                     childNodeID = std::stoi(currentLine.substr(findMidPosition + 3, findEndPosition - 1 - findMidPosition - 3));
                 } else {
                     std::cout << "Error in extracting childNodeID\n";
@@ -314,7 +334,7 @@ class Tree : public Object {
                 }
 
                 if (currentLine.find("yes, missing") != std::string::npos) {
-                    tree[parentNodeID].isMissTrackLeft = true; // previous, default value is set to no/right
+                    tree[parentNodeID].isMissTrackLeft = true; // in processInnerNodes(), default value is set to no/right
                 }
             } else { // modelType == ModelType::LightGBM
 #if 1

--- a/src/builtInPDBObjects/headers/TreeCrossProduct.h
+++ b/src/builtInPDBObjects/headers/TreeCrossProduct.h
@@ -1,11 +1,10 @@
 #ifndef TREE_CROSS_PRODUCT_H
 #define TREE_CROSS_PRODUCT_H
 
-
 #include "CrossProductComp.h"
+#include "LambdaCreationFunctions.h"
 #include "PDBString.h"
 #include "StringIntPair.h"
-#include "LambdaCreationFunctions.h"
 #include "TensorBlock2D.h"
 #include "Tree.h"
 #include "TreeResult.h"
@@ -15,20 +14,28 @@
 using namespace pdb;
 
 class TreeCrossProduct : public CrossProductComp {
+  private:
+    bool hasMissing;
 
-public:
+  public:
     ENABLE_DEEP_COPY
 
-    TreeCrossProduct() {this->joinType = CrossProduct;}
-
+    TreeCrossProduct() : hasMissing{false} { this->joinType = CrossProduct; }
+    TreeCrossProduct(bool hasMissing) : hasMissing{hasMissing} { this->joinType = CrossProduct; }
 
     Lambda<Handle<TreeResult>> getProjection(Handle<Tree> in1, Handle<TensorBlock2D<float>> in2) override {
-        return makeLambda(in1, in2, [](Handle<Tree>& in1, Handle<TensorBlock2D<float>>& in2) {
-            Handle<TreeResult> result = in1->predict(in2);
-            return result;
-        });
+        if (hasMissing) {
+            return makeLambda(in1, in2, [](Handle<Tree> &in1, Handle<TensorBlock2D<float>> &in2) {
+                Handle<TreeResult> result = in1->predictWithMissingValues(in2);
+                return result;
+            });
+        } else {
+            return makeLambda(in1, in2, [](Handle<Tree> &in1, Handle<TensorBlock2D<float>> &in2) {
+                Handle<TreeResult> result = in1->predictWithoutMissingValues(in2);
+                return result;
+            });
+        }
     }
 };
-
 
 #endif

--- a/src/builtInPDBObjects/headers/TreeNodeObjectBased.h
+++ b/src/builtInPDBObjects/headers/TreeNodeObjectBased.h
@@ -2,102 +2,98 @@
 #ifndef NETSDB_TREE_NODE_OBJECT_BASED_H
 #define NETSDB_TREE_NODE_OBJECT_BASED_H
 
-
+#include "PDBClient.h"
+#include "StorageClient.h"
+#include "TensorBlock2D.h"
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <iostream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <cstring>
-#include <string>
+#include <fcntl.h>
 #include <filesystem>
+#include <fstream>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
-#include <algorithm>
-#include <map>
-#include <set>
-#include "TensorBlock2D.h"
-#include "PDBClient.h"
-#include "StorageClient.h"
+#include <vector>
 
 // PRELOAD %TreeNodeObjectBased%
 
-namespace pdb
-{
+namespace pdb {
 
-    class TreeNodeObjectBased : public Object {
-    
-    public:
+class TreeNodeObjectBased : public Object {
 
-         TreeNodeObjectBased () {
-	    leftChild = nullptr;
-            rightChild = nullptr;
-	 }
+  public:
+    TreeNodeObjectBased() {
+        leftChild = nullptr;
+        rightChild = nullptr;
+    }
 
-	 ~TreeNodeObjectBased () {
-            leftChild = nullptr;
-	    rightChild = nullptr;
-         }
+    ~TreeNodeObjectBased() {
+        leftChild = nullptr;
+        rightChild = nullptr;
+    }
 
-	 // normally these would be defined by the ENABLE_DEEP_COPY macro, but because
-         // TreeNode is the one variable-sized type that we allow, we need to manually override
-         // these methods
-         void setUpAndCopyFrom(void* target, void* source) const override {
-             new (target) TreeNodeObjectBased ();
-             TreeNodeObjectBased& fromMe = *((TreeNodeObjectBased *) source);
-             TreeNodeObjectBased& toMe = *((TreeNodeObjectBased *) target);
-             if (fromMe.leftChild == nullptr)
-                 toMe.leftChild = nullptr;
-	     else {
-	         toMe.leftChild = makeObject<TreeNodeObjectBased>();
-		 toMe.leftChild = fromMe.leftChild;
-	     }
-	     if (fromMe.rightChild == nullptr)
-                 toMe.rightChild = nullptr;
-             else {
-                 toMe.rightChild = makeObject<TreeNodeObjectBased>();
-                 toMe.rightChild = fromMe.rightChild;
-             }
-             toMe.index = fromMe.index;
-             toMe.returnClass = fromMe.returnClass;
-         }
+    // normally these would be defined by the ENABLE_DEEP_COPY macro, but because
+    // TreeNode is the one variable-sized type that we allow, we need to manually override
+    // these methods
+    void setUpAndCopyFrom(void *target, void *source) const override {
+        new (target) TreeNodeObjectBased();
+        TreeNodeObjectBased &fromMe = *((TreeNodeObjectBased *)source);
+        TreeNodeObjectBased &toMe = *((TreeNodeObjectBased *)target);
+        if (fromMe.leftChild == nullptr)
+            toMe.leftChild = nullptr;
+        else {
+            toMe.leftChild = makeObject<TreeNodeObjectBased>();
+            toMe.leftChild = fromMe.leftChild;
+        }
+        if (fromMe.rightChild == nullptr)
+            toMe.rightChild = nullptr;
+        else {
+            toMe.rightChild = makeObject<TreeNodeObjectBased>();
+            toMe.rightChild = fromMe.rightChild;
+        }
+        toMe.index = fromMe.index;
+        toMe.threshold = fromMe.threshold;
+    }
 
-	 void deleteObject(void* deleteMe) override {
-             deleter(deleteMe, this);
-         }
+    void deleteObject(void *deleteMe) override {
+        deleter(deleteMe, this);
+    }
 
-         size_t getSize(void* forMe) override {
-             return sizeof(TreeNodeObjectBased);
-         }
+    size_t getSize(void *forMe) override {
+        return sizeof(TreeNodeObjectBased);
+    }
 
-         void print() {
-	
-	     std::cout << "index = " << index << ", returnClass = " << returnClass << std::endl;
-	     if (leftChild != nullptr)
-		 leftChild->print(); 
-	     if (rightChild != nullptr)
-		 rightChild->print();
-	 }
+    void print() {
 
+        std::cout << "index = " << index << ", threshold/leafValue = " << threshold << std::endl;
+        if (leftChild != nullptr)
+            leftChild->print();
+        if (rightChild != nullptr)
+            rightChild->print();
+    }
 
-         int index = -1;
-         Handle<TreeNodeObjectBased> leftChild = nullptr;
-         Handle<TreeNodeObjectBased> rightChild = nullptr;
-	 // returnClass will be the vaule to compare while this is not a leaf node
-         float returnClass =0.0; 
+    int index = -1;
+    Handle<TreeNodeObjectBased> leftChild = nullptr;
+    Handle<TreeNodeObjectBased> rightChild = nullptr;
+
+    union {
+        float threshold = 0.0;
+        float leafValue;
     };
+};
 
-}
+} // namespace pdb
 
 #endif // NETSDB_TREENODEOBJECTBASED_H

--- a/src/builtInPDBObjects/headers/TreeResult.h
+++ b/src/builtInPDBObjects/headers/TreeResult.h
@@ -51,14 +51,13 @@ class TreeResult : public Object {
     int blockSize;
 
     ModelType modelType;
-    bool isClassification;
 
     TreeResult() {}
 
     ~TreeResult() {}
 
-    TreeResult(int treeId, int batchId, int blockSize, ModelType modelType, bool isClassification)
-        : treeId{treeId}, batchId{batchId}, blockSize{blockSize}, modelType{modelType}, isClassification{isClassification} {
+    TreeResult(int treeId, int batchId, int blockSize, ModelType modelType)
+        : treeId{treeId}, batchId{batchId}, blockSize{blockSize}, modelType{modelType} {
         this->data = makeObject<Vector<float>>(blockSize, blockSize);
     }
 
@@ -98,17 +97,18 @@ class TreeResult : public Object {
         return positive_count;
     }
 #if 1
-    void postprocessing(Handle<TreeResult> &res, int numTrees = 0) {
+    void postprocessing(Handle<TreeResult> &res, bool isClassification, int numTrees) {
         float *resData = res->data->c_ptr();
         float *myData = data->c_ptr();
-        if (modelType == ModelType::RandomForest) {
-            for (int i = 0; i < blockSize; i++) {
-                resData[i] = myData[i] / numTrees;
-            }
+
+        for (int i = 0; i < blockSize; i++) {
+            resData[i] = (modelType == ModelType::RandomForest)
+                             ? myData[i] / numTrees
+                             : myData[i];
         }
         if (isClassification) {
             for (int i = 0; i < blockSize; i++) {
-                resData[i] = (myData[i] > 0.5) ? 1.0 : 0.0;
+                resData[i] = (resData[i] > 0.5) ? 1.0 : 0.0;
             }
         }
     }

--- a/src/builtInPDBObjects/headers/TreeResult.h
+++ b/src/builtInPDBObjects/headers/TreeResult.h
@@ -87,8 +87,7 @@ class TreeResult : public Object {
         return *this;
     }
 
-    int getNumPositives() {
-
+    int getNumPositives() const {
         float *myData = data->c_ptr();
         int positive_count = 0;
         for (int i = 0; i < blockSize; i++) {
@@ -96,6 +95,16 @@ class TreeResult : public Object {
         }
         return positive_count;
     }
+
+    double getBlockSum() const {
+        float *myData = data->c_ptr();
+        double sum = 0;
+        for (int i = 0; i < blockSize; i++) {
+            sum += static_cast<double>(myData[i]);
+        }
+        return sum;
+    }
+
 #if 1
     void postprocessing(Handle<TreeResult> &res, bool isClassification, int numTrees) {
         float *resData = res->data->c_ptr();

--- a/src/builtInPDBObjects/headers/TreeResult.h
+++ b/src/builtInPDBObjects/headers/TreeResult.h
@@ -51,17 +51,15 @@ class TreeResult : public Object {
     int blockSize;
 
     ModelType modelType;
+    bool isClassification;
 
     TreeResult() {}
 
     ~TreeResult() {}
 
-    TreeResult(int treeId, int batchId, int blockSize, ModelType modelType) {
+    TreeResult(int treeId, int batchId, int blockSize, ModelType modelType, bool isClassification)
+        : treeId{treeId}, batchId{batchId}, blockSize{blockSize}, modelType{modelType}, isClassification{isClassification} {
         this->data = makeObject<Vector<float>>(blockSize, blockSize);
-        this->treeId = treeId;
-        this->batchId = batchId;
-        this->blockSize = blockSize;
-        this->modelType = modelType;
     }
 
     int &getKey() {
@@ -100,7 +98,7 @@ class TreeResult : public Object {
         return positive_count;
     }
 #if 1
-    void postprocessing(Handle<TreeResult> &res, int numTrees = 0, bool isClassification = true) {
+    void postprocessing(Handle<TreeResult> &res, int numTrees = 0) {
         float *resData = res->data->c_ptr();
         float *myData = data->c_ptr();
         if (modelType == ModelType::RandomForest) {

--- a/src/builtInPDBObjects/headers/TreeResultPostProcessing.h
+++ b/src/builtInPDBObjects/headers/TreeResultPostProcessing.h
@@ -1,78 +1,69 @@
 #ifndef TREERESULTPOSTPROCESSING_H
 #define TREERESULTPOSTPROCESSING_H
 
-
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <fcntl.h>
 #include <fstream>
-#include <iostream>
-#include <vector>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
-#include <string>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
-#include <algorithm>
-#include <map>
-#include <set>
-#include <cstring>
-#include <exception>
+#include <vector>
 
-#include "Object.h"
-#include "PDBVector.h"
-#include "PDBString.h"
 #include "Handle.h"
-#include "TensorBlock2D.h"
 #include "Lambda.h"
 #include "LambdaCreationFunctions.h"
+#include "Object.h"
+#include "PDBString.h"
+#include "PDBVector.h"
 #include "SelectionComp.h"
+#include "TensorBlock2D.h"
 #include "TreeResult.h"
-
 
 // PRELOAD %TreeResultPostProcessing%
 
+namespace pdb {
+class TreeResultPostProcessing : public SelectionComp<TreeResult, TreeResult> {
 
-namespace pdb 
-{
-    class TreeResultPostProcessing : public SelectionComp<TreeResult, TreeResult>
-    {
+  public:
+    ENABLE_DEEP_COPY
 
-    public:
-        ENABLE_DEEP_COPY
+    int numTrees = 0;
 
-	int numTrees = 0;
+    TreeResultPostProcessing() {}
 
-	TreeResultPostProcessing() {}
+    TreeResultPostProcessing(int numTrees) {
+        this->numTrees = numTrees;
+        std::cout << "TreeResultPostProcessing is initialized to have " << numTrees << " trees" << std::endl;
+    }
 
-	TreeResultPostProcessing (int numTrees){
-             this->numTrees = numTrees;
-             std::cout << "TreeResultPostProcessing is initialized to have " << numTrees << " trees" << std::endl;
-	}
+    Lambda<bool> getSelection(Handle<TreeResult> checkMe) override {
+        return makeLambda(checkMe,
+                          [](Handle<TreeResult> &checkMe) { return true; });
+    }
 
-        Lambda<bool> getSelection(Handle<TreeResult> checkMe) override
-        {
-            return makeLambda(checkMe,
-                              [](Handle<TreeResult> &checkMe)
-                              { return true; });
-        }
+    Lambda<Handle<TreeResult>> getProjection(Handle<TreeResult> in) override {
+        return makeLambda(in, [this](Handle<TreeResult> &in) {
 
-        Lambda<Handle<TreeResult>> getProjection(Handle<TreeResult> in) override
-        {
-            return makeLambda(in, [this](Handle<TreeResult> &in) {
-
-		Handle<TreeResult> out = makeObject<TreeResult>(0, in->batchId, in->blockSize, in->modelType);
+		Handle<TreeResult> out = makeObject<TreeResult>(0, in->batchId, in->blockSize, in->modelType, in->isClassification);
                 in->postprocessing(out, numTrees); 
 
                 return out; });
-        }
-    };
-}
+    }
+};
+} // namespace pdb
 
 #endif

--- a/src/builtInPDBObjects/headers/TreeResultPostProcessing.h
+++ b/src/builtInPDBObjects/headers/TreeResultPostProcessing.h
@@ -42,12 +42,14 @@ class TreeResultPostProcessing : public SelectionComp<TreeResult, TreeResult> {
     ENABLE_DEEP_COPY
 
     int numTrees = 0;
+    bool isClassification;
 
     TreeResultPostProcessing() {}
 
-    TreeResultPostProcessing(int numTrees) {
-        this->numTrees = numTrees;
-        std::cout << "TreeResultPostProcessing is initialized to have " << numTrees << " trees" << std::endl;
+    TreeResultPostProcessing(int numTrees, bool isClassification)
+        : numTrees{numTrees}, isClassification{isClassification} {
+        std::cout << "TreeResultPostProcessing is initialized to have " << numTrees
+                  << " trees. isClassification=" << (isClassification ? "True\n" : "False\n");
     }
 
     Lambda<bool> getSelection(Handle<TreeResult> checkMe) override {
@@ -57,11 +59,9 @@ class TreeResultPostProcessing : public SelectionComp<TreeResult, TreeResult> {
 
     Lambda<Handle<TreeResult>> getProjection(Handle<TreeResult> in) override {
         return makeLambda(in, [this](Handle<TreeResult> &in) {
-
-		Handle<TreeResult> out = makeObject<TreeResult>(0, in->batchId, in->blockSize, in->modelType, in->isClassification);
-                in->postprocessing(out, numTrees); 
-
-                return out; });
+		    Handle<TreeResult> out = makeObject<TreeResult>(0, in->batchId, in->blockSize, in->modelType);
+            in->postprocessing(out, isClassification, numTrees); 
+            return out; });
     }
 };
 } // namespace pdb

--- a/src/conf/headers/DataTypes.h
+++ b/src/conf/headers/DataTypes.h
@@ -113,12 +113,12 @@ enum struct ModelType {
 };
 
 typedef struct {
-    short indexID;
-    bool isLeaf;
-    short leftChild;
-    short rightChild;
     // returnClass will be the vaule to compare while this is not a leaf node
     float returnClass;
+    short indexID;
+    short leftChild;
+    short rightChild;
+    bool isLeaf;
     // When feature value is missing, whether track/traverseTo the left node
     bool isMissTrackLeft;
 } Node;

--- a/src/conf/headers/DataTypes.h
+++ b/src/conf/headers/DataTypes.h
@@ -114,7 +114,10 @@ enum struct ModelType {
 
 typedef struct {
     // returnClass will be the vaule to compare while this is not a leaf node
-    float returnClass;
+    union {
+        float threshold;
+        float leafValue;
+    };
     short indexID;
     short leftChild;
     short rightChild;

--- a/src/tests/source/TestDecisionForest.cc
+++ b/src/tests/source/TestDecisionForest.cc
@@ -271,21 +271,33 @@ int main(int argc, char *argv[]) {
         bool printResult = true;
         if (printResult == true) {
             std::cout << "to print result..." << std::endl;
-            int count = 0;
-            int positive_count = 0;
+
             if (isFloat) {
-
-                pdb::SetIterator<pdb::Vector<float>> result =
-                    pdbClient.getSetIterator<pdb::Vector<float>>("decisionForest", "labels");
-
-                for (auto a : result) {
-                    for (int i = 0; i < a->size(); i++) {
-                        count++;
-                        positive_count += (*a)[i];
+                pdb::SetIterator<pdb::Vector<float>> result = pdbClient.getSetIterator<pdb::Vector<float>>("decisionForest", "labels");
+                int count = 0;
+                if (isClassification) {
+                    int positiveCounts = 0;
+                    for (auto a : result) {
+                        for (int i = 0; i < a->size(); i++) {
+                            count++;
+                            positiveCounts += (*a)[i];
+                        }
                     }
+                    std::cout << "output count:" << count << "\n";
+                    std::cout << "positive count:" << positiveCounts << "\n";
+                } else { // TODO: support larger outputs for regression tasks
+                    double sum = 0.0;
+                    for (auto a : result) {
+                        for (int i = 0; i < a->size(); i++) {
+                            count++;
+                            sum += (*a)[i];
+                        }
+                    }
+                    double mean = sum / count;
+                    std::cout << "output count:" << count << "\n";
+                    std::cout << "output mean:" << mean << '\n';
                 }
-                std::cout << "output count:" << count << "\n";
-                std::cout << "positive count:" << positive_count << "\n";
+
             } else {
 
                 pdb::SetIterator<pdb::Vector<double>> result =

--- a/src/tests/source/TestDecisionForest.cc
+++ b/src/tests/source/TestDecisionForest.cc
@@ -44,10 +44,10 @@ using namespace std;
 int main(int argc, char *argv[]) {
 
     const char *helperString =
-        "Usage: \n To load data: bin/testDecisionForest Y numInstances numFeatures batch_size label_col_index isFloat[F/D] isGraphOrArray[G/A] pageSizeInMB numPartitions pathToLoadDataFile(N for generating data randomly) \n"
-        "To run the inference: bin/testDecisionForest N numInstances numFeatures batchSize label_col_index isFloat[F/D] isGraphOrArray [G/A] pageSizeInMB numPartitions pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n"
-        "Example: \n bin/testDecisionForest Y 2200000 28 275000 0 F A 32 1 withoutMissing model-inference/decisionTree/experiments/HIGGS.csv_test.csv\n"
-        "bin/testDecisionForest N 2200000 28 275000 0 F A 32 1 withoutMissing model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
+        "Usage: \n To load data: bin/testDecisionForest Y numInstances numFeatures batch_size label_col_index isFloat[F/D] isGraphOrArray[G/A] pageSizeInMB numPartitions pathToLoadDataFile(N for generating data randomly) dataHasMissingValues[withMissing/withoutMissing]\n"
+        "To run the inference: bin/testDecisionForest N numInstances numFeatures batchSize label_col_index isFloat[F/D] isGraphOrArray [G/A] pageSizeInMB numPartitions pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest/LightGBM] dataHasMissingValues[withMissing/withoutMissing]\n"
+        "Example: \n bin/testDecisionForest Y 2200000 28 275000 0 F A 32 1 model-inference/decisionTree/experiments/HIGGS.csv_test.csv withoutMissing\n"
+        "bin/testDecisionForest N 2200000 28 275000 0 F A 32 1 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost withoutMissing\n";
     bool createSet;
 
     if ((argc <= 8) || (argc > 14)) {

--- a/src/tests/source/TestDecisionForestWithCrossProduct.cc
+++ b/src/tests/source/TestDecisionForestWithCrossProduct.cc
@@ -1,107 +1,101 @@
 #ifndef TEST_DECISION_FOREST_WITH_CROSSPRODUCT_CC
 #define TEST_DECISION_FOREST_WITH_CROSSPRODUCT_CC
 
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <vector>
-#include <cmath>
-#include <cstdlib>
-#include <cstring>
 #include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <fcntl.h>
+#include <fstream>
 #include <future>
-#include <thread>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
-#include <string>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
+#include <string>
 #include <sys/mman.h>
+#include <thread>
 #include <unistd.h>
-#include <cassert>
-#include <memory>
 #include <vector>
-#include <map>
-#include <set>
-#include <cstdio>
-#include <exception>
-#include <cassert>
 
+#include "FFMatrixUtil.h"
 #include "PDBClient.h"
+#include "ScanUserSet.h"
+#include "SimpleFF.h"
 #include "StorageClient.h"
-#include "PDBClient.h"
 #include "TensorBlock2D.h"
 #include "Tree.h"
-#include "TreeResult.h"
-#include "TreeResultPostProcessing.h"
-#include "ScanUserSet.h"
-#include "WriteUserSet.h"
-#include "FFMatrixUtil.h"
-#include "SimpleFF.h"
-#include "TreeResultAggregate.h"
 #include "TreeCrossProduct.h"
+#include "TreeResult.h"
+#include "TreeResultAggregate.h"
+#include "TreeResultPostProcessing.h"
+#include "WriteUserSet.h"
 using namespace std;
-
 
 using std::filesystem::directory_iterator;
 
-int loadTreeData(PDBClient& pdbClient, std::string forestFolderPath, ModelType modelType) {
+int loadTreeData(PDBClient &pdbClient, std::string forestFolderPath, ModelType modelType) {
 
-	std::vector<std::string> treePaths;
+    std::vector<std::string> treePaths;
 
-	std::string errMsg;
+    std::string errMsg;
 
-        makeObjectAllocatorBlock(16 * 1024 * 1024, true);
-	Handle<Vector<Handle<Tree>>> storeMe =
-                    makeObject<Vector<Handle<Tree>>>();
+    makeObjectAllocatorBlock(16 * 1024 * 1024, true);
+    Handle<Vector<Handle<Tree>>> storeMe =
+        makeObject<Vector<Handle<Tree>>>();
 
-	int treeId = 0;
-        for (const auto & file : directory_iterator(forestFolderPath)) {
-	     std::string treePath = file.path(); 	
-	     try {
-                 Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType);             
-                 treePaths.push_back(treePath);
-		 storeMe->push_back(tree);
-             } catch (pdb::NotEnoughSpace& n) {
-		 std::cout << "page is full when loading tree-" << treeId << std::endl;
-	         //send the full page to server
-                 if (!pdbClient.sendData<Tree>(
-                            std::pair<std::string, std::string>("trees", "decisionForest"),
-                            storeMe,
-                            errMsg)) {
-                        std::cout << "Failed to send data to dispatcher server" << std::endl;
-                 }
-		 makeObjectAllocatorBlock(16 * 1024 * 1024, true);
-                 storeMe = makeObject<Vector<Handle<Tree>>>();
-                 Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType);
-                 storeMe->push_back(tree);
-	     }
-	     treeId++;
+    int treeId = 0;
+    for (const auto &file : directory_iterator(forestFolderPath)) {
+        std::string treePath = file.path();
+        try {
+            Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType);
+            treePaths.push_back(treePath);
+            storeMe->push_back(tree);
+        } catch (pdb::NotEnoughSpace &n) {
+            std::cout << "page is full when loading tree-" << treeId << std::endl;
+            // send the full page to server
+            if (!pdbClient.sendData<Tree>(
+                    std::pair<std::string, std::string>("trees", "decisionForest"),
+                    storeMe,
+                    errMsg)) {
+                std::cout << "Failed to send data to dispatcher server" << std::endl;
+            }
+            makeObjectAllocatorBlock(16 * 1024 * 1024, true);
+            storeMe = makeObject<Vector<Handle<Tree>>>();
+            Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType);
+            storeMe->push_back(tree);
         }
-
-	if (!pdbClient.sendData<Tree>(
-                            std::pair<std::string, std::string>("trees", "decisionForest"),
-                            storeMe,
-                            errMsg)) {
-                        std::cout << "Failed to send data to dispatcher server" << std::endl;
-                 }
-
-	pdbClient.flushData(errMsg);
-
-	return treeId;
-
+        treeId++;
     }
 
+    if (!pdbClient.sendData<Tree>(
+            std::pair<std::string, std::string>("trees", "decisionForest"),
+            storeMe,
+            errMsg)) {
+        std::cout << "Failed to send data to dispatcher server" << std::endl;
+    }
+
+    pdbClient.flushData(errMsg);
+
+    return treeId;
+}
 
 int main(int argc, char *argv[]) {
 
-
     bool createSet;
-
-    if ((argc <= 8)||(argc > 12)) {
-    
-        std::cout << "Usage: \n To load data: bin/testDecisionForestWithCrossProduct Y numInstances numFeatures batch_size label_col_index, pageSizeInMB numPartitions pathToLoadDataFile(N for generating data randomly) pathToModelFolder modelType[XGBoost/RandomForest]\n To run the inference: bin/testDecisionForestWithCrossProduct N numInstances numFeatures batchSize labelColIndex pageSizeInMB numPartitions pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n Example: \n bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 1 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n bin/testDecisionForestWithCrossProduct N 2200000 28 275000 0 32 1 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
+    const char *helperString =
+        "Usage: \n To load data: bin/testDecisionForestWithCrossProduct Y numInstances numFeatures batch_size label_col_index, pageSizeInMB numPartitions pathToLoadDataFile(N for generating data randomly) pathToModelFolder modelType[XGBoost/RandomForest]\n"
+        "To run the inference: bin/testDecisionForestWithCrossProduct N numInstances numFeatures batchSize labelColIndex pageSizeInMB numPartitions pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n"
+        "Example: \n bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 1 withoutMissing model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n"
+        "bin/testDecisionForestWithCrossProduct N 2200000 28 275000 0 32 1 withoutMissing model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
+    if ((argc <= 8) || (argc > 13)) {
+        std::cout << helperString;
         exit(-1);
     }
 
@@ -117,38 +111,35 @@ int main(int argc, char *argv[]) {
     int numPartitions = 1;
     string dataFilePath = "";
     int numTrees = 0;
+    bool hasMissing = false;
 
+    if (argc >= 8) {
 
-    if(argc >= 8) {
-
-        if(string(argv[1]).compare("Y")==0) {
+        if (string(argv[1]).compare("Y") == 0) {
             createSet = true;
         } else {
             createSet = false;
         }
-    
-        rowNum = std::stoi(argv[2]);  //total size of input feature vectors
-        colNum = std::stoi(argv[3]);  //number of features
-        block_x = std::atoi(argv[4]); //batch size
-        block_y = colNum; //numFeatures
 
-        label_col_index = std::atoi(argv[5]);//the index of label column
+        rowNum = std::stoi(argv[2]);  // total size of input feature vectors
+        colNum = std::stoi(argv[3]);  // number of features
+        block_x = std::atoi(argv[4]); // batch size
+        block_y = colNum;             // numFeatures
+
+        label_col_index = std::atoi(argv[5]); // the index of label column
 
         if (argc >= 7) {
             pageSize = std::stoi(argv[6]);
         }
 
-	if (argc >= 8) {
+        if (argc >= 8) {
             numPartitions = std::stoi(argv[7]);
         }
-
     }
 
     if (argc >= 9) {
         dataFilePath = std::string(argv[8]);
     }
-
-
 
     if (argc >= 10) {
         forestFolderPath = std::string(argv[9]);
@@ -160,10 +151,11 @@ int main(int argc, char *argv[]) {
         } else if (string(argv[10]).compare("RandomForest") == 0) {
             modelType = ModelType::RandomForest;
         } else if (string(argv[10]).compare("LightGBM") == 0) {
-	    modelType = ModelType::LightGBM;
-	} else {
+            modelType = ModelType::LightGBM;
+        } else {
             std::cerr << "Unsupported model type: " << argv[10] << std::endl;
-	    exit(-1);
+            std::cerr << helperString;
+            exit(-1);
         }
     }
 
@@ -171,102 +163,109 @@ int main(int argc, char *argv[]) {
         numTrees = std::stoi(argv[11]);
     }
 
+    if (argc >= 13) {
+        if (std::string(argv[12]).compare("withMissing") == 0) {
+            hasMissing = true;
+        } else if (std::string(argv[12]).compare("withoutMissing") == 0) {
+            hasMissing = false;
+        } else {
+            std::cerr << "Please provide an argument `withMissing` or `withoutMissing` to specify the character of the data\n";
+            std::cerr << helperString;
+            exit(-1);
+        }
+    }
 
     string masterIp = "localhost";
     pdb::PDBLoggerPtr clientLogger = make_shared<pdb::PDBLogger>("DecisionForestClientLog");
     pdb::PDBClient pdbClient(8108, masterIp, clientLogger, false, true);
     pdb::CatalogClient catalogClient(8108, masterIp, clientLogger);
 
-
-    if(createSet == true){
-        //create set for data
+    if (createSet == true) {
+        // create set for data
         ff::createDatabase(pdbClient, "decisionForest");
         ff::createSetGeneric<pdb::TensorBlock2D<float>>(pdbClient, "decisionForest", "inputs", "inputs", pageSize, numPartitions);
         if (dataFilePath.compare("N") == 0) {
 
             if (numPartitions == 1)
-	        ff::loadMatrixGeneric<pdb::TensorBlock2D<float>>(pdbClient, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, false, false, errMsg);		   
+                ff::loadMatrixGeneric<pdb::TensorBlock2D<float>>(pdbClient, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, false, false, errMsg);
             else {
-		std::cout << "Currently we only support single partition for randomly generated input data" << std::endl;
-		exit(1);
-	    }
-	} else {
-	    ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<float>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, label_col_index, errMsg, 4*pageSize, numPartitions);
-	}
+                std::cout << "Currently we only support single partition for randomly generated input data" << std::endl;
+                exit(1);
+            }
+        } else {
+            ff::loadMatrixGenericFromFile<pdb::TensorBlock2D<float>>(pdbClient, dataFilePath, "decisionForest", "inputs", rowNum, colNum, block_x, block_y, label_col_index, errMsg, 4 * pageSize, numPartitions);
+        }
 
-	//create set for tree
+        // create set for tree
         pdbClient.removeSet("decisionForest", "trees", errMsg);
         pdbClient.createSet<pdb::Tree>("decisionForest", "trees",
-                                           errMsg, 8*1024*1024, "trees",
-                                           nullptr, nullptr, false);
-	
+                                       errMsg, 8 * 1024 * 1024, "trees",
+                                       nullptr, nullptr, false);
+
         auto model_begin = chrono::high_resolution_clock::now();
-	int numTrees = loadTreeData(pdbClient, forestFolderPath, modelType);
+        int numTrees = loadTreeData(pdbClient, forestFolderPath, modelType);
         auto model_end = chrono::high_resolution_clock::now();
-	std::cout << numTrees << " trees loaded" << std::endl;
+        std::cout << numTrees << " trees loaded" << std::endl;
         std::cout << "****Model Load Time Duration: ****"
-              << std::chrono::duration_cast<std::chrono::duration<double>>(model_end-model_begin).count()
-                                                                        << " secs." << std::endl;
+                  << std::chrono::duration_cast<std::chrono::duration<double>>(model_end - model_begin).count()
+                  << " secs." << std::endl;
     } else {
         std::cout << "Not create a set and not load new data to the input set" << std::endl;
     }
-   
+
     if (createSet == false) {
 
-	//create set for labels
+        // create set for labels
         pdbClient.removeSet("decisionForest", "labels", errMsg);
         pdbClient.createSet<pdb::TreeResult>("decisionForest", "labels",
-                                           errMsg, 64*1024*1024, "labels",
-                                           nullptr, nullptr, false);
+                                             errMsg, 64 * 1024 * 1024, "labels",
+                                             nullptr, nullptr, false);
 
         pdb::makeObjectAllocatorBlock(1024 * 1024 * 1024, true);
 
         auto begin = std::chrono::high_resolution_clock::now();
 
-
-	for (int i = 0; i < numPartitions; i++) {
+        for (int i = 0; i < numPartitions; i++) {
 
             pdb::Handle<pdb::Computation> inputMatrix = nullptr;
-	    
-	    if (numPartitions == 1)
-		    inputMatrix = pdb::makeObject<pdb::ScanUserSet<pdb::TensorBlock2D<float>>>("decisionForest", "inputs");
-	    else
-	            inputMatrix = pdb::makeObject<pdb::ScanUserSet<pdb::TensorBlock2D<float>>>("decisionForest", std::string("inputs")+std::to_string(i));
 
-	    pdb::Handle<pdb::Computation> inputTree = pdb::makeObject<pdb::ScanUserSet<Tree>>("decisionForest", "trees");
+            if (numPartitions == 1)
+                inputMatrix = pdb::makeObject<pdb::ScanUserSet<pdb::TensorBlock2D<float>>>("decisionForest", "inputs");
+            else
+                inputMatrix = pdb::makeObject<pdb::ScanUserSet<pdb::TensorBlock2D<float>>>("decisionForest", std::string("inputs") + std::to_string(i));
 
-            pdb::Handle<pdb::CrossProductComp> treeCrossProduct = makeObject<TreeCrossProduct>();
+            pdb::Handle<pdb::Computation> inputTree = pdb::makeObject<pdb::ScanUserSet<Tree>>("decisionForest", "trees");
+
+            pdb::Handle<pdb::CrossProductComp> treeCrossProduct = makeObject<TreeCrossProduct>(hasMissing);
 
             treeCrossProduct->setJoinType(CrossProduct);
 
             if (treeCrossProduct->getJoinType() == CrossProduct) {
-	
-	       std::cout << "The join is CrossProduct" << std::endl;
 
-	    } else {
-	
-	       std::cout << "The join is not CrossProduct" << std::endl;
-	
-	    }
+                std::cout << "The join is CrossProduct" << std::endl;
 
-	    pdb::Handle<pdb::Computation> treeResultAgg = makeObject<pdb::TreeResultAggregate>();
-        
-            treeResultAgg->setUsingCombiner(false);         
+            } else {
 
-	    treeCrossProduct->setInput(0, inputTree);
+                std::cout << "The join is not CrossProduct" << std::endl;
+            }
 
-	    treeCrossProduct->setInput(1, inputMatrix);
+            pdb::Handle<pdb::Computation> treeResultAgg = makeObject<pdb::TreeResultAggregate>();
 
+            treeResultAgg->setUsingCombiner(false);
+
+            treeCrossProduct->setInput(0, inputTree);
+
+            treeCrossProduct->setInput(1, inputMatrix);
 
             treeResultAgg->setInput(treeCrossProduct);
 
-            pdb::Handle<pdb::Computation> treeResultPostProcessing = makeObject<pdb::TreeResultPostProcessing>( numTrees );
-	
+            pdb::Handle<pdb::Computation> treeResultPostProcessing = makeObject<pdb::TreeResultPostProcessing>(numTrees);
+
             treeResultPostProcessing->setInput(treeResultAgg);
 
-	    pdb::Handle<pdb::Computation> resultWriter = makeObject<WriteUserSet<TreeResult>>("decisionForest", "labels");
+            pdb::Handle<pdb::Computation> resultWriter = makeObject<WriteUserSet<TreeResult>>("decisionForest", "labels");
 
-	    resultWriter->setInput(treeResultPostProcessing);
+            resultWriter->setInput(treeResultPostProcessing);
 
             bool materializeHash = true;
 
@@ -278,33 +277,33 @@ int main(int argc, char *argv[]) {
             auto exe_end = std::chrono::high_resolution_clock::now();
 
             std::cout << i << ":****Model Inference Time Duration: ****"
-                << std::chrono::duration_cast<std::chrono::duration<double>>(exe_end - exe_begin).count()
-                                                                        << " secs." << std::endl;
-       }
+                      << std::chrono::duration_cast<std::chrono::duration<double>>(exe_end - exe_begin).count()
+                      << " secs." << std::endl;
+        }
 
-       auto end = std::chrono::high_resolution_clock::now();
+        auto end = std::chrono::high_resolution_clock::now();
 
-       std::cout << "****Overall Inference Time Duration: ****"
-                << std::chrono::duration_cast<std::chrono::duration<double>>(end - begin).count()
-                                                                        << " secs." << std::endl;
+        std::cout << "****Overall Inference Time Duration: ****"
+                  << std::chrono::duration_cast<std::chrono::duration<double>>(end - begin).count()
+                  << " secs." << std::endl;
 
-       bool printResult = true;
-       if (printResult == true) {
-           std::cout << "to print result..." << std::endl;
-           int count = 0;
-           int positive_count = 0;
+        bool printResult = true;
+        if (printResult == true) {
+            std::cout << "to print result..." << std::endl;
+            int count = 0;
+            int positive_count = 0;
 
-           pdb::SetIterator<pdb::TreeResult> result =
-           pdbClient.getSetIterator<pdb::TreeResult>("decisionForest", "labels");
+            pdb::SetIterator<pdb::TreeResult> result =
+                pdbClient.getSetIterator<pdb::TreeResult>("decisionForest", "labels");
 
-           for (auto a : result) {
-               positive_count += a->getNumPositives();
-               count += a->blockSize;
-           }
-           std::cout << "total count:" << count << "\n";
-           std::cout << "positive count:" << positive_count << "\n";
-       }
-       return 0;
+            for (auto a : result) {
+                positive_count += a->getNumPositives();
+                count += a->blockSize;
+            }
+            std::cout << "total count:" << count << "\n";
+            std::cout << "positive count:" << positive_count << "\n";
+        }
+        return 0;
     }
 }
 

--- a/src/tests/source/TestDecisionForestWithCrossProduct.cc
+++ b/src/tests/source/TestDecisionForestWithCrossProduct.cc
@@ -54,7 +54,7 @@ int loadTreeData(PDBClient &pdbClient, std::string forestFolderPath, ModelType m
     for (const auto &file : directory_iterator(forestFolderPath)) {
         std::string treePath = file.path();
         try {
-            Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType, isClassification);
+            Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType);
             treePaths.push_back(treePath);
             storeMe->push_back(tree);
         } catch (pdb::NotEnoughSpace &n) {
@@ -68,7 +68,7 @@ int loadTreeData(PDBClient &pdbClient, std::string forestFolderPath, ModelType m
             }
             makeObjectAllocatorBlock(16 * 1024 * 1024, true);
             storeMe = makeObject<Vector<Handle<Tree>>>();
-            Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType, isClassification);
+            Handle<Tree> tree = makeObject<Tree>(treeId, treePath, modelType);
             storeMe->push_back(tree);
         }
         treeId++;
@@ -270,7 +270,7 @@ int main(int argc, char *argv[]) {
 
             treeResultAgg->setInput(treeCrossProduct);
 
-            pdb::Handle<pdb::Computation> treeResultPostProcessing = makeObject<pdb::TreeResultPostProcessing>(numTrees);
+            pdb::Handle<pdb::Computation> treeResultPostProcessing = makeObject<pdb::TreeResultPostProcessing>(numTrees, isClassification);
 
             treeResultPostProcessing->setInput(treeResultAgg);
 

--- a/src/tests/source/TestDecisionForestWithCrossProduct.cc
+++ b/src/tests/source/TestDecisionForestWithCrossProduct.cc
@@ -90,10 +90,10 @@ int main(int argc, char *argv[]) {
 
     bool createSet;
     const char *helperString =
-        "Usage: \n To load data: bin/testDecisionForestWithCrossProduct Y numInstances numFeatures batch_size label_col_index, pageSizeInMB numPartitions pathToLoadDataFile(N for generating data randomly) pathToModelFolder modelType[XGBoost/RandomForest]\n"
-        "To run the inference: bin/testDecisionForestWithCrossProduct N numInstances numFeatures batchSize labelColIndex pageSizeInMB numPartitions pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest]\n"
-        "Example: \n bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 1 withoutMissing model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n"
-        "bin/testDecisionForestWithCrossProduct N 2200000 28 275000 0 32 1 withoutMissing model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost\n";
+        "Usage: \n To load data: bin/testDecisionForestWithCrossProduct Y numInstances numFeatures batch_size label_col_index, pageSizeInMB numPartitions pathToLoadDataFile(N for generating data randomly) pathToModelFolder modelType[XGBoost/RandomForest/LightGBM] dataHasMissingValues[withMissing/withoutMissing]\n"
+        "To run the inference: bin/testDecisionForestWithCrossProduct N numInstances numFeatures batchSize labelColIndex pageSizeInMB numPartitions pathToLoadDataFile pathToModelFolder modelType[XGBoost/RandomForest/LightGBM] dataHasMissingValues[withMissing/withoutMissing]\n"
+        "Example: \n bin/testDecisionForestWithCrossProduct Y 2200000 28 275000 0 32 1 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost withoutMissing\n"
+        "bin/testDecisionForestWithCrossProduct N 2200000 28 275000 0 32 1 model-inference/decisionTree/experiments/HIGGS.csv_test.csv model-inference/decisionTree/experiments/models/higgs_xgboost_500_8_netsdb XGBoost withoutMissing\n";
     if ((argc <= 8) || (argc > 13)) {
         std::cout << helperString;
         exit(-1);

--- a/src/tests/source/TestDecisionForestWithCrossProduct.cc
+++ b/src/tests/source/TestDecisionForestWithCrossProduct.cc
@@ -301,18 +301,26 @@ int main(int argc, char *argv[]) {
         bool printResult = true;
         if (printResult == true) {
             std::cout << "to print result..." << std::endl;
+            pdb::SetIterator<pdb::TreeResult> result = pdbClient.getSetIterator<pdb::TreeResult>("decisionForest", "labels");
             int count = 0;
-            int positive_count = 0;
-
-            pdb::SetIterator<pdb::TreeResult> result =
-                pdbClient.getSetIterator<pdb::TreeResult>("decisionForest", "labels");
-
-            for (auto a : result) {
-                positive_count += a->getNumPositives();
-                count += a->blockSize;
+            if (isClassification) {
+                int positiveCounts = 0;
+                for (auto a : result) {
+                    positiveCounts += a->getNumPositives();
+                    count += a->blockSize;
+                }
+                std::cout << "total count:" << count << "\n";
+                std::cout << "positive count:" << positiveCounts << "\n";
+            } else { // TODO: support larger outputs for regression tasks
+                double sum = 0.0;
+                for (auto a : result) {
+                    sum += a->getBlockSum();
+                    count += a->blockSize;
+                }
+                double mean = sum / count;
+                std::cout << "total count:" << count << "\n";
+                std::cout << "output mean:" << mean << '\n';
             }
-            std::cout << "total count:" << count << "\n";
-            std::cout << "positive count:" << positive_count << "\n";
         }
         return 0;
     }


### PR DESCRIPTION
Main updates: 
1. Support converting LightGBM pickle file to CSV files and loading LightGBM model from CSV files
2. Dispatch predict() function according to user input (withMissing/withoutMissing values in data); the dispatching speeds up 1600 trees Randomforest model on Higgs dataset.
3. Change the aggregation functions for all algorithms. I believe the aggregation function is wrong, so I changed it. The details are described in my previous document. The basic idea is simple, for xgboost and lightgbm, the aggregated predicted value is just the sum of all predicted leaf values. For random forest, the aggregated predicted value is the mean of all predicted leaf values. If it is a classification task, the forest outputs class one if the aggregated value is greater than 0.5 and class zero otherwise.
4. Enable regression tasks and support the "Year" dataset.
5. Support loading SVM data input to dense matrices.

Some code refactoring:
1. Change returnClass in data structures to a union of threshold (for inner nodes) and leafValue (for leaf nodes).
2. Refactor the function that loads the matrix from an input file to make it easier to understand.